### PR TITLE
Determine SFSpeechRecognizer Locale and fallback

### DIFF
--- a/Frameworks/RichEditor/Sources/RichEditor/SimpleSpeech/SimpleSpeechController+Task.swift
+++ b/Frameworks/RichEditor/Sources/RichEditor/SimpleSpeech/SimpleSpeechController+Task.swift
@@ -37,8 +37,8 @@ extension SimpleSpeechController {
 
     func stopTranscript() {
         for item in sessionItems {
-            if let item = item as? SFSpeechRecognitionTask {
-                item.cancel()
+            if let task = item as? SFSpeechRecognitionTask {
+                task.cancel()
             }
         }
         sessionItems.removeAll()
@@ -60,6 +60,13 @@ extension SimpleSpeechController {
             ])
         }
 
+        // appLang if non‐English, otherwise Locale.preferredLanguages.first
+        let appLang = Bundle.main.preferredLocalizations.first ?? "en"
+        let preferred = (appLang != "en") ? appLang
+                       : Locale.preferredLanguages.first ?? "en"
+        let localeID = preferred.replacingOccurrences(of: "_", with: "-")
+        let speechLocale = Locale(identifier: localeID)
+        
         let audioSession = AVAudioSession.sharedInstance()
         try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
         try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
@@ -70,7 +77,7 @@ extension SimpleSpeechController {
         recognitionRequest.shouldReportPartialResults = true
         recognitionRequest.requiresOnDeviceRecognition = false
 
-        guard let speechRecognizer = SFSpeechRecognizer() else {
+        guard let speechRecognizer = SFSpeechRecognizer(locale: speechLocale) else {
             throw NSError(domain: "SpeechRecognizer", code: 0, userInfo: [
                 NSLocalizedDescriptionKey: NSLocalizedString("Speech recognizer is not available.", bundle: .module, comment: ""),
             ])


### PR DESCRIPTION
## Reason for this PR

Not everyone sets the first language of the device as the preferred language, the same for Siri Language.

For such a reason, my proposal is to pick `speechLocale` based on these factors:
a) Picks the app’s preferred localization.
b) If the app language is English, it switches to the device’s primary language.
c) Falls back to English if any issues are met.

## Examples

```
Situation One:
System Locale: English
App Locale: Chinese
Speech Locale: Chinese
---
Situation Two:
System Locale: Japanese
App Locale: English (since not supporting jp)
Speech Locale: Japanese
---
Situation Three:
System Locale: English
App Locale: English
Speech Locale: English
```