### PR TITLE
fix: cancel autofocus on sidebar

### DIFF
--- a/FlowDown/Interface/Components/ChatView/ChatView.swift
+++ b/FlowDown/Interface/Components/ChatView/ChatView.swift
@@ -157,19 +157,15 @@ class ChatView: UIView {
                 self?.editor.updateModelName()
             }
             .store(in: &cancellables)
-
-        NotificationCenter.default.publisher(for: .newChatCreated)
-            .debounce(for: .seconds(0.5), scheduler: DispatchQueue(label: "wiki.qaq.editor.focus"))
-            .ensureMainThread()
-            .sink { [weak self] _ in
-                self?.editor.focus()
-            }
-            .store(in: &cancellables)
     }
 
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError()
+    }
+
+    func focusEditor() {
+        editor.focus()
     }
 
     func prepareForReuse() {
@@ -179,8 +175,9 @@ class ChatView: UIView {
         editor.prepareForReuse()
     }
 
-    func use(conversation: Conversation.ID) {
+    func use(conversation: Conversation.ID, completion: (() -> Void)? = nil) {
         if conversationIdentifier == conversation {
+            completion?()
             return
         }
         conversationIdentifier = conversation
@@ -196,6 +193,9 @@ class ChatView: UIView {
 
         offloadModelsToSession(modelIdentifier: modelIdentifier())
         removeUnusedListViews()
+        DispatchQueue.main.async {
+            completion?()
+        }
     }
 
     override func layoutSubviews() {

--- a/FlowDown/Interface/ViewController/MainController/MainController+Content.swift
+++ b/FlowDown/Interface/ViewController/MainController/MainController+Content.swift
@@ -15,8 +15,7 @@ extension MainController {
 
         contentView.contentView.addSubview(chatView)
         chatView.onCreateNewChat = { [weak self] in
-            guard let self else { return }
-            sidebar.newChatButton.didTap()
+            self?.requestNewChat()
         }
         chatView.onSuggestNewChat = { [weak self] id in
             guard let self else { return }

--- a/FlowDown/Interface/ViewController/MainController/MainController.swift
+++ b/FlowDown/Interface/ViewController/MainController/MainController.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Storage
 import UIKit
 
 class MainController: UIViewController {
@@ -115,6 +116,7 @@ class MainController: UIViewController {
         }
 
         setupViews()
+        sidebar.newChatButton.delegate = self
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -287,7 +289,11 @@ class MainController: UIViewController {
     }
 
     @objc func requestNewChat() {
-        sidebar.newChatButton.didTap()
+        let conv = ConversationManager.shared.createNewConversation()
+        sidebar.newChatDidCreated(conv.id)
+        chatView.use(conversation: conv.id) { [weak self] in
+            self?.chatView.focusEditor()
+        }
     }
 
     @objc func openSettings() {
@@ -300,6 +306,13 @@ class MainController: UIViewController {
         guard !models.isEmpty else { return }
         print("[*] opening models \(models)")
         ModelManager.shared.importModels(at: models, controller: self)
+    }
+}
+
+extension MainController: NewChatButton.Delegate {
+    func newChatDidCreated(_ identifier: Conversation.ID) {
+        sidebar.newChatDidCreated(identifier)
+        chatView.use(conversation: identifier)
     }
 }
 


### PR DESCRIPTION
Since creating a new conversation in the SideBar also automatically focuses and brings up the keyboard, it affects the user experience.