### PR TITLE
Initial Handling URL Scheme

### DIFF
--- a/FlowDown/Application/SceneDelegate.swift
+++ b/FlowDown/Application/SceneDelegate.swift
@@ -93,7 +93,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             handleNewMessageURL(url)
         default:
             print("[*] Unknown action: \(host), just opening app")
-            break
         }
     }
 
@@ -112,7 +111,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         print("[*] Encoded message: \(encodedMessage)")
 
         guard let message = encodedMessage.removingPercentEncoding,
-            !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+              !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
             print("[*] Failed to decode message or message is empty")
             return

--- a/FlowDown/Application/SceneDelegate.swift
+++ b/FlowDown/Application/SceneDelegate.swift
@@ -23,7 +23,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
-    func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    static var supposeToSendMessage: String? {
+        didSet {
+            guard let message = supposeToSendMessage, !message.isEmpty else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                NotificationCenter.default.post(name: .sendNewMessage, object: message)
+            }
+        }
+    }
+
+    func scene(
+        _ scene: UIScene, willConnectTo _: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         #if targetEnvironment(macCatalyst)
             if let titlebar = windowScene.titlebar {
@@ -56,7 +68,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             default: break // dont know how
             }
         case "flowdown":
-            break // just open our app
+            handleFlowDownURL(url)
         default:
             break
         }
@@ -66,6 +78,48 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         _ = url.startAccessingSecurityScopedResource()
         try? FileManager.default.startDownloadingUbiquitousItem(at: url)
         Self.supposeToOpenModel.append(url)
+    }
+
+    private func handleFlowDownURL(_ url: URL) {
+        print("[*] Handling FlowDown URL: \(url)")
+        guard let host = url.host(), !host.isEmpty else {
+            print("[*] No host found, just opening app")
+            return
+        }
+
+        print("[*] URL host: \(host)")
+        switch host {
+        case "new":
+            handleNewMessageURL(url)
+        default:
+            print("[*] Unknown action: \(host), just opening app")
+            break
+        }
+    }
+
+    private func handleNewMessageURL(_ url: URL) {
+        print("[*] Handling new message URL: \(url)")
+        let pathComponents = url.pathComponents
+        print("[*] Path components: \(pathComponents)")
+
+        guard pathComponents.count >= 2 else {
+            print("[*] Invalid format, should be /message")
+            return
+        }
+
+        // extract msg from path
+        let encodedMessage = pathComponents[1]
+        print("[*] Encoded message: \(encodedMessage)")
+
+        guard let message = encodedMessage.removingPercentEncoding,
+            !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            print("[*] Failed to decode message or message is empty")
+            return
+        }
+
+        print("[*] Decoded message: \(message)")
+        Self.supposeToSendMessage = message
     }
 
     func sceneDidDisconnect(_: UIScene) {}
@@ -81,4 +135,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 extension Notification.Name {
     static let openModel = Notification.Name("openModel")
+    static let sendNewMessage = Notification.Name("sendNewMessage")
 }

--- a/FlowDown/Interface/ViewController/MainController/MainController.swift
+++ b/FlowDown/Interface/ViewController/MainController/MainController.swift
@@ -192,16 +192,17 @@ class MainController: UIViewController {
         lastTouchBegin = .init()
 
         NSObject.cancelPreviousPerformRequests(
-            withTarget: self, selector: #selector(resetGestures), object: nil)
+            withTarget: self, selector: #selector(resetGestures), object: nil
+        )
         perform(#selector(resetGestures), with: nil, afterDelay: 0.25)
     }
 
     func isTouchingHandlerBarArea(_ touches: Set<UITouch>) -> Bool {
         #if targetEnvironment(macCatalyst)
             if presentedViewController == nil,
-                touches.count == 1,
-                let touch = touches.first,
-                let window = view.window
+               touches.count == 1,
+               let touch = touches.first,
+               let window = view.window
             {
                 if false
                     || touch.location(in: window).y < 32
@@ -227,7 +228,8 @@ class MainController: UIViewController {
         super.touchesMoved(touches, with: event)
 
         NSObject.cancelPreviousPerformRequests(
-            withTarget: self, selector: #selector(resetGestures), object: nil)
+            withTarget: self, selector: #selector(resetGestures), object: nil
+        )
         perform(#selector(resetGestures), with: nil, afterDelay: 0.25)
         guard presentedViewController == nil else { return }
         #if !targetEnvironment(macCatalyst)
@@ -247,9 +249,9 @@ class MainController: UIViewController {
     #if targetEnvironment(macCatalyst)
         func performZoom() {
             guard let appClass = NSClassFromString("NSApplication") as? NSObject.Type,
-                let sharedApp = appClass.value(forKey: "sharedApplication") as? NSObject,
-                sharedApp.responds(to: NSSelectorFromString("windows")),
-                let windowsArray = sharedApp.value(forKey: "windows") as? [NSObject]
+                  let sharedApp = appClass.value(forKey: "sharedApplication") as? NSObject,
+                  sharedApp.responds(to: NSSelectorFromString("windows")),
+                  let windowsArray = sharedApp.value(forKey: "windows") as? [NSObject]
             else {
                 return
             }
@@ -267,8 +269,7 @@ class MainController: UIViewController {
         defer { resetGestures() }
         guard presentedViewController == nil else { return }
         guard let touch = touches.first else { return }
-        if !isSidebarCollapsed, !touchesMoved, contentView.frame.contains(touch.location(in: view))
-        {
+        if !isSidebarCollapsed, !touchesMoved, contentView.frame.contains(touch.location(in: view)) {
             view.doWithAnimation { self.isSidebarCollapsed = true }
             return
         }
@@ -364,8 +365,9 @@ class MainController: UIViewController {
                 title: String(localized: "No Model Available"),
                 message: String(
                     localized:
-                        "Please add some models to use. You can choose to download models, or use cloud model from well known service providers."
-                ))
+                    "Please add some models to use. You can choose to download models, or use cloud model from well known service providers."
+                )
+            )
             return
         }
         print("[*] Using model: \(modelID)")
@@ -379,7 +381,8 @@ class MainController: UIViewController {
         let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedMessage.isEmpty else {
             showErrorAlert(
-                title: String(localized: "Error"), message: String(localized: "Empty message."))
+                title: String(localized: "Error"), message: String(localized: "Empty message.")
+            )
             return
         }
         print("[*] Message content: '\(trimmedMessage)'")
@@ -410,12 +413,12 @@ class MainController: UIViewController {
 }
 
 #if targetEnvironment(macCatalyst)
-    extension UIResponder {
-        fileprivate func dispatchTouchAsWindowMovement() {
+    fileprivate extension UIResponder {
+        func dispatchTouchAsWindowMovement() {
             guard let appType = NSClassFromString("NSApplication") as? NSObject.Type,
-                let nsApp = appType.value(forKey: "sharedApplication") as? NSObject,
-                let currentEvent = nsApp.value(forKey: "currentEvent") as? NSObject,
-                let nsWindow = currentEvent.value(forKey: "window") as? NSObject
+                  let nsApp = appType.value(forKey: "sharedApplication") as? NSObject,
+                  let currentEvent = nsApp.value(forKey: "currentEvent") as? NSObject,
+                  let nsWindow = currentEvent.value(forKey: "window") as? NSObject
             else { return }
             nsWindow.perform(
                 NSSelectorFromString("performWindowDragWithEvent:"),

--- a/FlowDown/Interface/ViewController/MainController/MainController.swift
+++ b/FlowDown/Interface/ViewController/MainController/MainController.swift
@@ -8,7 +8,6 @@
 import AlertController
 import Combine
 import RichEditor
-import Storage
 import UIKit
 
 class MainController: UIViewController {


### PR DESCRIPTION
## Changes

- Now, `flowdown://` no longer only acts as a shortcut to open FlowDown. It now enables the feature to create new conversation directly from URL Scheme.
- Introduces `handleFlowDownURL()`

## URL Scheme Format

```
flowdown://new/[encoded_message]
```

Where:
- `flowdown://`: Custom URL Scheme
- `new`: new conversation
- `[encoded_message]`: URL-encoded message


### Examples

Create a new conversation with "Hello World":
```
flowdown://new/Hello%20World
```

A more complex request...
```
flowdown://new/When%20will%20FlowDown%202%20be%20released%3F%20What%20new%20features%20can%20we%20expect%3F
```