### PR TITLE
fix: NewChat autofocus on mac

### DIFF
--- a/FlowDown/Interface/ViewController/MainController/MainController.swift
+++ b/FlowDown/Interface/ViewController/MainController/MainController.swift
@@ -421,7 +421,11 @@ class MainController: UIViewController {
 extension MainController: NewChatButton.Delegate {
     func newChatDidCreated(_ identifier: Conversation.ID) {
         sidebar.newChatDidCreated(identifier)
-        chatView.use(conversation: identifier)
+        chatView.use(conversation: identifier) { [weak self] in
+            #if targetEnvironment(macCatalyst)
+                self?.chatView.focusEditor()
+            #endif
+        }
     }
 }
 


### PR DESCRIPTION
Let autofocus when use mac, and not autofocus on ios.