### PR TITLE
Add Menu items via UIMenuBuilder

### DIFF
--- a/FlowDown/Application/AppDelegate+Menu.swift
+++ b/FlowDown/Application/AppDelegate+Menu.swift
@@ -1,0 +1,97 @@
+//
+//  AppDelegate+Menu.swift
+//  FlowDown
+//
+//  Created by Alan Ye on 6/27/25.
+//
+
+import AlertController
+import Storage
+import UIKit
+
+extension AppDelegate {
+    // MARK: - Menu Building
+    override func buildMenu(with builder: UIMenuBuilder) {
+        super.buildMenu(with: builder)
+        guard builder.system == UIMenuSystem.main else { return }
+        
+        builder.insertChild(
+            UIMenu(
+                title: "",
+                options: .displayInline,
+                children: [
+                    UIKeyCommand(
+                        title: String(localized: "New Chat"),
+                        action: #selector(requestNewChatFromMenu(_:)),
+                        input: "n",
+                        modifierFlags: .command
+                    )
+                ]
+            ),
+            atStartOfMenu: .file
+        )
+        builder.insertChild(
+            UIMenu(
+                title: "",
+                options: .displayInline,
+                children: [
+                    UIKeyCommand(
+                        title: String(localized: "Delete Chat"),
+                        action: #selector(deleteConversationFromMenu(_:)),
+                        input: "\u{8}",
+                        modifierFlags: [.command]
+                    )
+                ]
+            ),
+            atEndOfMenu: .file
+        )
+        builder.insertSibling(
+            UIMenu(
+                title: "",
+                options: .displayInline,
+                children: [
+                    UIKeyCommand(
+                        title: String(localized: "Settings..."),
+                        action: #selector(openSettingsFromMenu(_:)),
+                        input: ",",
+                        modifierFlags: .command
+                    )
+                ]
+            ),
+            afterMenu: .preferences
+        )
+    }
+
+    // MARK: - Menu Actions
+    var mainWindow: UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.windows.first }
+            .first
+    }
+
+    // Wire from MainController
+    @objc func requestNewChatFromMenu(_ sender: Any?) {
+        (mainWindow?.rootViewController as? MainController)?.requestNewChat()
+    }
+
+    @objc func openSettingsFromMenu(_ sender: Any?) {
+        (mainWindow?.rootViewController as? MainController)?.openSettings()
+    }
+
+    // Conversation related
+    private func withCurrentConversation(_ block: (MainController, Conversation.ID, Conversation) -> Void) {
+        guard let mainVC = mainWindow?.rootViewController as? MainController,
+              let conversationID = mainVC.chatView.conversationIdentifier,
+              let conversation = ConversationManager.shared.conversation(identifier: conversationID)
+        else {
+            return
+        }
+        block(mainVC, conversationID, conversation)
+    }
+
+    @objc func deleteConversationFromMenu(_ sender: Any?) {
+        withCurrentConversation { mainVC, conversationID, _ in
+            ConversationManager.shared.deleteConversation(identifier: conversationID)
+        }
+    }
+}

--- a/FlowDown/Interface/ViewController/MainController/MainController.swift
+++ b/FlowDown/Interface/ViewController/MainController/MainController.swift
@@ -277,22 +277,6 @@ class MainController: UIViewController {
         }
     }
 
-    override var keyCommands: [UIKeyCommand]? {
-        var commands = [
-            UIKeyCommand(
-                input: "n",
-                modifierFlags: .command,
-                action: #selector(requestNewChat)
-            ),
-            UIKeyCommand(
-                input: ",",
-                modifierFlags: .command,
-                action: #selector(openSettings)
-            ),
-        ]
-        return commands
-    }
-
     @objc func resetGestures() {
         firstTouchLocation = nil
         touchesMoved = false

--- a/FlowDown/Resources/Localizable.xcstrings
+++ b/FlowDown/Resources/Localizable.xcstrings
@@ -1096,6 +1096,16 @@
         }
       }
     },
+    "Delete Chat" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除对话"
+          }
+        }
+      }
+    },
     "Delete Conversation" : {
       "localizations" : {
         "zh-Hans" : {
@@ -2910,6 +2920,16 @@
         }
       }
     },
+    "New Chat" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建对话"
+          }
+        }
+      }
+    },
     "No events found between %@ and %@." : {
       "localizations" : {
         "en" : {
@@ -3726,6 +3746,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置"
+          }
+        }
+      }
+    },
+    "Settings..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置…"
           }
         }
       }


### PR DESCRIPTION
- Ported "New Chat" and "Settings..." to Menu Bar
- Newly added "Delete Chat" (Command + Delete)

Tested: Available on Mac Catalyst & iPadOS 26 Menu Bar