### PR TITLE
Add initial Apple Intelligence support

### DIFF
--- a/FlowDown/Backend/Model/ModelManager+AAPL.swift
+++ b/FlowDown/Backend/Model/ModelManager+AAPL.swift
@@ -1,0 +1,176 @@
+//
+//  ModelManager+AAPL.swift
+//  FlowDown
+//
+//  Created by Alan Ye on 6/30/25.
+//
+
+import Foundation
+import UIKit
+import ChatClientKit
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+// MARK: - Apple Intelligence Model
+
+/// Represents the Apple Intelligence on-device model (iOS 26+ only).
+@available(iOS 26.0, macCatalyst 26.0, *)
+final class AppleIntelligenceModel {
+    static let shared = AppleIntelligenceModel()
+    /// Returns true if the device supports Apple Intelligence and the model is available.
+    var isAvailable: Bool {
+        if #available(iOS 26.0, macCatalyst 26.0, *) {
+            #if canImport(FoundationModels)
+            let model = SystemLanguageModel.default
+            switch model.availability {
+            case .available:
+                return true
+            default:
+                return false
+            }
+            #else
+            return false
+            #endif
+        } else {
+            return false
+        }
+    }
+    var availabilityStatus: String {
+        if #available(iOS 26.0, macCatalyst 26.0, *) {
+            #if canImport(FoundationModels)
+            let model = SystemLanguageModel.default
+            switch model.availability {
+            case .available:
+                return "Available"
+            case .unavailable(.deviceNotEligible):
+                return "Device Not Eligible"
+            case .unavailable(.appleIntelligenceNotEnabled):
+                return "Apple Intelligence Not Enabled"
+            case .unavailable(.modelNotReady):
+                return "Model Not Ready"
+            case .unavailable(let other):
+                return "Unavailable: \(other)"
+            }
+            #else
+            return "Not Supported"
+            #endif
+        } else {
+            return "Requires iOS 26+"
+        }
+    }
+    var modelDisplayName: String {
+        return "Apple Intelligence (On-Device)"
+    }
+    var modelIdentifier: String {
+        return "apple.intelligence.ondevice"
+    }
+    var modelInfo: [String: String] {
+        return [
+            "identifier": modelIdentifier,
+            "displayName": modelDisplayName,
+            "status": availabilityStatus
+        ]
+    }
+}
+
+// MARK: - Chat Client
+
+class AppleIntelligenceChatClient: ChatService {
+    // MARK: - ChatService Protocol
+    var collectedErrors: String?
+
+    func chatCompletionRequest(body: ChatRequestBody) async throws -> ChatResponseBody {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macCatalyst 26.0, *) {
+            // instructions (first .system message)
+            let instructions = body.messages.compactMap { message -> String? in
+                if case let .system(content, _) = message {
+                    return extractText(content)
+                }
+                return nil
+            }.first ?? ""
+            // prompt (last .user message)
+            let prompt = body.messages.reversed().compactMap { message -> String? in
+                if case let .user(content, _) = message {
+                    return extractText(content)
+                }
+                return nil
+            }.first ?? ""
+            let session = LanguageModelSession(instructions: instructions)
+            let response = try await session.respond(to: prompt)
+            let message = ChatChoice(
+                finishReason: "stop",
+                message: ChoiceMessage(
+                    content: response.content,
+                    reasoning: nil,
+                    reasoningContent: nil,
+                    role: "assistant",
+                    toolCalls: nil
+                )
+            )
+            return ChatResponseBody(
+                choices: [message],
+                created: Int(Date().timeIntervalSince1970),
+                model: "apple-intelligence",
+                usage: nil,
+                systemFingerprint: nil
+            )
+        } else {
+            throw NSError(domain: "AppleIntelligence", code: -1, userInfo: [NSLocalizedDescriptionKey: "Requires iOS 26+"])
+        }
+        #else
+        throw NSError(domain: "AppleIntelligence", code: -1, userInfo: [NSLocalizedDescriptionKey: "FoundationModels not available"])
+        #endif
+    }
+
+    func streamingChatCompletionRequest(body: ChatRequestBody) async throws -> AnyAsyncSequence<ChatServiceStreamObject> {
+        let response = try await chatCompletionRequest(body: body)
+        return AnyAsyncSequence(AsyncStream<ChatServiceStreamObject> { continuation in
+            for choice in response.choices {
+                let chunk = ChatCompletionChunk(
+                    choices: [
+                        ChatCompletionChunk.Choice(
+                            delta: ChatCompletionChunk.Choice.Delta(
+                                content: choice.message.content,
+                                reasoning: choice.message.reasoning,
+                                reasoningContent: choice.message.reasoningContent,
+                                refusal: nil,
+                                role: choice.message.role,
+                                toolCalls: nil
+                            ),
+                            finishReason: choice.finishReason,
+                            index: nil
+                        )
+                    ],
+                    created: response.created,
+                    id: nil,
+                    model: response.model,
+                    serviceTier: nil,
+                    systemFingerprint: response.systemFingerprint,
+                    usage: response.usage
+                )
+                continuation.yield(.chatCompletionChunk(chunk: chunk))
+            }
+            continuation.finish()
+        })
+    }
+}
+
+// MARK: - Helpers
+
+private func extractText<T>(_ content: T) -> String {
+    switch content {
+    case let text as String:
+        return text
+    case let parts as [String]:
+        return parts.joined(separator: " ")
+    case let parts as [Any]:
+        return parts.compactMap { ($0 as? String) }.joined(separator: " ")
+    default:
+        if let value = content as? CustomStringConvertible {
+            return value.description
+        }
+        return ""
+    }
+}

--- a/FlowDown/Backend/Model/ModelManager+Inference.swift
+++ b/FlowDown/Backend/Model/ModelManager+Inference.swift
@@ -13,6 +13,9 @@ import MLXLLM
 import MLXLMCommon
 import MLXVLM
 import Storage
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
 
 extension ModelManager {
     // - imageProcessingFailure : "height: 1 must be larger than factor: 28"
@@ -215,12 +218,47 @@ extension ModelManager {
             completion(.success(()))
         }.resume()
     }
+
+    func testAppleIntelligenceModel(completion: @escaping (Result<Void, Error>) -> Void) {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macCatalyst 26.0, *) {
+            guard AppleIntelligenceModel.shared.isAvailable else {
+                completion(.failure(NSError(domain: "AppleIntelligence", code: -1, userInfo: [NSLocalizedDescriptionKey: "Apple Intelligence not available on this device."])));
+                return
+            }
+            Task {
+                do {
+                    let session = LanguageModelSession()
+                    let prompt = "Reply YES to every query. YES or NO"
+                    let response = try await session.respond(to: prompt)
+                    if !response.content.isEmpty {
+                        completion(.success(()))
+                    } else {
+                        completion(.failure(NSError(domain: "AppleIntelligence", code: -1, userInfo: [NSLocalizedDescriptionKey: "No response from Apple Intelligence."])));
+                    }
+                } catch {
+                    completion(.failure(error))
+                }
+            }
+        } else {
+            completion(.failure(NSError(domain: "AppleIntelligence", code: -1, userInfo: [NSLocalizedDescriptionKey: "Requires iOS 26+"])));
+        }
+        #else
+        completion(.failure(NSError(domain: "AppleIntelligence", code: -1, userInfo: [NSLocalizedDescriptionKey: "FoundationModels not available"])));
+        #endif
+    }
 }
 
 extension ModelManager {
     static let indicatorText = " ●"
 
     private func chatService(for identifier: ModelIdentifier, additionalBodyField: [String: Any]) throws -> any ChatService {
+
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macCatalyst 26.0, *), identifier == AppleIntelligenceModel.shared.modelIdentifier {
+            return AppleIntelligenceChatClient()
+        }
+        #endif
         if let model = cloudModel(identifier: identifier) {
             return RemoteChatClient(
                 model: model.model_identifier,

--- a/FlowDown/Backend/Model/ModelManager+Menu.swift
+++ b/FlowDown/Backend/Model/ModelManager+Menu.swift
@@ -42,8 +42,16 @@ extension ModelManager {
         let cloudModels = ModelManager.shared.cloudModels.value.filter {
             !$0.model_identifier.isEmpty
         }.filter { requiresCapabilities.isSubset(of: $0.capabilities) }
+        
 
-        if localModels.isEmpty, cloudModels.isEmpty {
+        var appleIntelligenceAvailable = false
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macCatalyst 26.0, *) {
+            appleIntelligenceAvailable = AppleIntelligenceModel.shared.isAvailable
+        }
+        #endif
+        
+        if localModels.isEmpty, cloudModels.isEmpty, !appleIntelligenceAvailable {
             let alert = AlertViewController(
                 title: String(localized: "No Model Available"),
                 message: requiresCapabilities.isEmpty
@@ -140,6 +148,18 @@ extension ModelManager {
                 onCompletion("")
             })
         }
+
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macCatalyst 26.0, *), appleIntelligenceAvailable {
+            finalChildren.append(UIAction(
+                title: AppleIntelligenceModel.shared.modelDisplayName,
+                image: UIImage(systemName: "apple.intelligence"),
+                state: currentSelection == AppleIntelligenceModel.shared.modelIdentifier ? .on : .off
+            ) { _ in
+                onCompletion(AppleIntelligenceModel.shared.modelIdentifier)
+            })
+        }
+        #endif
 
         if !localMenuChildren.isEmpty {
             finalChildren.append(UIMenu(

--- a/FlowDown/Backend/Model/ModelManager.swift
+++ b/FlowDown/Backend/Model/ModelManager.swift
@@ -125,9 +125,21 @@ class ModelManager: NSObject {
     }
 
     func checkDefaultModels() {
+        #if canImport(FoundationModels)
+        let appleIntelligenceId: String? = {
+            if #available(iOS 26.0, macCatalyst 26.0, *) {
+                return AppleIntelligenceModel.shared.modelIdentifier
+            } else {
+                return nil
+            }
+        }()
+        #else
+        let appleIntelligenceId: String? = nil
+        #endif
         if !defaultModelForConversation.isEmpty,
            localModel(identifier: defaultModelForConversation) == nil,
-           cloudModel(identifier: defaultModelForConversation) == nil
+           cloudModel(identifier: defaultModelForConversation) == nil,
+           !(appleIntelligenceId != nil && defaultModelForConversation == appleIntelligenceId)
         {
             print("[*] reset defaultModelForConversation due to not found")
             defaultModelForConversation = ""
@@ -135,7 +147,8 @@ class ModelManager: NSObject {
 
         if !defaultModelForAuxiliaryTask.isEmpty,
            localModel(identifier: defaultModelForAuxiliaryTask) == nil,
-           cloudModel(identifier: defaultModelForAuxiliaryTask) == nil
+           cloudModel(identifier: defaultModelForAuxiliaryTask) == nil,
+           !(appleIntelligenceId != nil && defaultModelForAuxiliaryTask == appleIntelligenceId)
         {
             print("[*] reset defaultModelForAuxiliaryTask due to not found")
             defaultModelForAuxiliaryTask = ""
@@ -144,7 +157,8 @@ class ModelManager: NSObject {
         if !defaultModelForAuxiliaryVisualTask.isEmpty {
             let localModelSatisfied = localModel(identifier: defaultModelForAuxiliaryVisualTask)?.capabilities.contains(.visual) ?? false
             let cloudModelSatisfied = cloudModel(identifier: defaultModelForAuxiliaryVisualTask)?.capabilities.contains(.visual) ?? false
-            if !localModelSatisfied, !cloudModelSatisfied {
+            let appleIntelligenceSatisfied = (appleIntelligenceId != nil && defaultModelForAuxiliaryVisualTask == appleIntelligenceId)
+            if !localModelSatisfied, !cloudModelSatisfied, !appleIntelligenceSatisfied {
                 print("[*] reset defaultModelForAuxiliaryVisualTask due to not found")
                 defaultModelForAuxiliaryVisualTask = ""
             }
@@ -153,6 +167,11 @@ class ModelManager: NSObject {
 
     func modelName(identifier: ModelIdentifier?) -> String {
         guard let identifier else { return "-" }
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macCatalyst 26.0, *), identifier == AppleIntelligenceModel.shared.modelIdentifier {
+            return AppleIntelligenceModel.shared.modelDisplayName
+        }
+        #endif
         return nil
             ?? cloudModel(identifier: identifier)?.modelFullName
             ?? localModel(identifier: identifier)?.model_identifier
@@ -160,6 +179,12 @@ class ModelManager: NSObject {
     }
 
     func modelCapabilities(identifier: ModelIdentifier) -> Set<ModelCapabilities> {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macCatalyst 26.0, *), identifier == AppleIntelligenceModel.shared.modelIdentifier {
+            // no endpoint
+            return [.tool]
+        }
+        #endif
         if let cloudModel = cloudModel(identifier: identifier) {
             return cloudModel.capabilities
         }
@@ -170,6 +195,13 @@ class ModelManager: NSObject {
     }
 
     func modelContextLength(identifier: ModelIdentifier) -> Int {
+
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, macCatalyst 26.0, *), identifier == AppleIntelligenceModel.shared.modelIdentifier {
+            // Apple Intelligence: context length is not public, use a safe default
+            return 8192
+        }
+        #endif
         if let cloudModel = cloudModel(identifier: identifier) {
             return cloudModel.context.rawValue
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Apple Intelligence on-device models (iOS 26+ and macCatalyst 26+), including model availability detection and chat capabilities.
  * Integrated Apple Intelligence model as a selectable option in the model selection menu and settings.
  * Enhanced chat functionality to use Apple Intelligence for completions and streaming responses when available.

* **Bug Fixes**
  * Improved logic to prevent "No Model Available" alerts if Apple Intelligence is present.

* **UI Improvements**
  * Updated menus and settings to display Apple Intelligence model names and handle their selection appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->