### PR TITLE
Remove disclosure indicator due to Apple HIG

### DIFF
--- a/FlowDown/Interface/ViewController/ConversationSearchController/ConversationSearchController+Cell.swift
+++ b/FlowDown/Interface/ViewController/ConversationSearchController/ConversationSearchController+Cell.swift
@@ -22,7 +22,6 @@ extension SearchContentController {
             super.init(style: style, reuseIdentifier: reuseIdentifier)
 
             backgroundColor = .clear
-            accessoryType = .disclosureIndicator
 
             iconView.contentMode = .scaleAspectFit
             iconView.layer.cornerRadius = 6


### PR DESCRIPTION
https://developer.apple.com/design/human-interface-guidelines/lists-and-tables#iOS-iPadOS-visionOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Shortcuts" menu accessible from the tools button, allowing quick access to "MCP Settings" and "Tools Settings".
  * Introduced a new settings page for "MCP Settings".
  * Right-clicking the tools toggle now presents alternative tool options.

* **Improvements**
  * Added Simplified Chinese translations for "MCP Settings" and "Tools Settings".

* **Style**
  * Removed the disclosure indicator from conversation search result cells for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->