### PR TITLE
Handle reasoning content standards gracefully

### DIFF
--- a/FlowDown/Backend/Model/ModelManager+Inference.swift
+++ b/FlowDown/Backend/Model/ModelManager+Inference.swift
@@ -332,8 +332,8 @@ extension ModelManager {
             )
         )
         let message = response.choices.first?.message
-        let reasoning = message?.reasoning ?? ""
-        let reasoningContent = message?.reasoningContent ?? ""
+        let reasoning = message?.reasoning ?? .init()
+        let reasoningContent = message?.reasoningContent ?? .init()
 
         let finalReasoning = if reasoning == reasoningContent, !reasoning.isEmpty {
             reasoning
@@ -371,8 +371,8 @@ extension ModelManager {
             switch streamObject {
             case let .chatCompletionChunk(chunk):
                 let delta = chunk.choices.first?.delta
-                let reasoning = delta?.reasoning ?? ""
-                let reasoningContent = delta?.reasoningContent ?? ""
+                let reasoning = delta?.reasoning ?? .init()
+                let reasoningContent = delta?.reasoningContent ?? .init()
 
                 msg.reasoningContent = if reasoning == reasoningContent, !reasoning.isEmpty {
                     reasoning

--- a/FlowDown/Backend/Model/ModelManager+Inference.swift
+++ b/FlowDown/Backend/Model/ModelManager+Inference.swift
@@ -332,8 +332,17 @@ extension ModelManager {
             )
         )
         let message = response.choices.first?.message
+        let reasoning = message?.reasoning ?? ""
+        let reasoningContent = message?.reasoningContent ?? ""
+
+        let finalReasoning = if reasoning == reasoningContent, !reasoning.isEmpty {
+            reasoning
+        } else {
+            [reasoning, reasoningContent].filter { !$0.isEmpty }.joined()
+        }
+
         return .init(
-            reasoningContent: message?.reasoningContent ?? .init(),
+            reasoningContent: finalReasoning,
             content: message?.content ?? .init(),
             // TODO: IMPL
             tool: []
@@ -362,10 +371,14 @@ extension ModelManager {
             switch streamObject {
             case let .chatCompletionChunk(chunk):
                 let delta = chunk.choices.first?.delta
-                msg.reasoningContent = [
-                    delta?.reasoning ?? .init(),
-                    delta?.reasoningContent ?? .init(),
-                ].joined()
+                let reasoning = delta?.reasoning ?? ""
+                let reasoningContent = delta?.reasoningContent ?? ""
+
+                msg.reasoningContent = if reasoning == reasoningContent, !reasoning.isEmpty {
+                    reasoning
+                } else {
+                    [reasoning, reasoningContent].filter { !$0.isEmpty }.joined()
+                }
                 msg.content = delta?.content ?? .init()
             case let .tool(call):
                 msg.toolCallRequests = [call]


### PR DESCRIPTION
> This is called, defensive programming. ;)

Handles the following situations:
- Models that only use ``reasoning`` field (Unchanged)
- Models that only use ``reasoningContent`` field (Unchanged)
- Models that provide both fields with different content (Unchanged, `joined()`)
- Models that provide both fields with identical content (Fixed here)

