### PR TITLE
Support display tool call running and error

### DIFF
--- a/FlowDown/Interface/Components/MessageListView/Components/ToolHintView.swift
+++ b/FlowDown/Interface/Components/MessageListView/Components/ToolHintView.swift
@@ -92,6 +92,11 @@ final class ToolHintView: MessageListRowView {
             let image = UIImage(systemName: "checkmark.seal", withConfiguration: configuration)
             symbolView.image = image
             symbolView.tintColor = .systemGreen
+        case .running:
+            contentView.backgroundColor = .systemBlue.withAlphaComponent(0.05)
+            let image = UIImage(systemName: "hourglass", withConfiguration: configuration)
+            symbolView.image = image
+            symbolView.tintColor = .systemBlue
         default:
             contentView.backgroundColor = .systemRed.withAlphaComponent(0.05)
             let image = UIImage(systemName: "xmark.seal", withConfiguration: configuration)
@@ -102,8 +107,17 @@ final class ToolHintView: MessageListRowView {
     }
 
     private func updateContent() {
-        isClickable = true
-        label.text = .init(localized: "Tool call for \(toolName) completed.")
+        switch state {
+        case .running:
+            isClickable = false
+            label.text = .init(localized: "Tool call for \(toolName) running.")
+        case .suceeded:
+            isClickable = true
+            label.text = .init(localized: "Tool call for \(toolName) completed.")
+        case .failed:
+            isClickable = true
+            label.text = .init(localized: "Tool call for \(toolName) failed.")
+        }
         label.invalidateIntrinsicContentSize()
         label.sizeToFit()
         setNeedsLayout()

--- a/FlowDown/Interface/Components/MessageListView/MessageListView+Adapter.swift
+++ b/FlowDown/Interface/Components/MessageListView/MessageListView+Adapter.swift
@@ -195,6 +195,8 @@ extension MessageListView: ListViewAdapter {
         } else if let toolHintView = rowView as? ToolHintView {
             if case let .toolCallStatus(status) = entry {
                 let state: ToolHintView.State = switch status.state {
+                case 0:
+                    .running
                 case 1:
                     .suceeded
                 default:

--- a/FlowDown/Resources/Localizable.xcstrings
+++ b/FlowDown/Resources/Localizable.xcstrings
@@ -6066,6 +6066,26 @@
         }
       }
     },
+    "Tool call for %@ failed." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工具 %@ 的调用失败。"
+          }
+        }
+      }
+    },
+    "Tool call for %@ running." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始调用工具 %@ 。"
+          }
+        }
+      }
+    },
     "Tool execution failed: %@" : {
       "localizations" : {
         "zh-Hans" : {


### PR DESCRIPTION
This pull request introduces enhanced error handling and status tracking for tool execution in the `FlowDown` project. The changes improve user feedback on tool execution states, refactor the tool execution logic, and update the UI to reflect these states more clearly.

### Tool Execution Logic Enhancements:
* Refactored `ModelToolsManager.perform` to return a `Result<String, Error>` instead of a nullable `String`, enabling better distinction between success and failure cases. [[1]](diffhunk://#diff-2daaa82cfcb0e9b9f130b10833f4b154dd105e64b89f3613d44d85469a460d88L117-R127) [[2]](diffhunk://#diff-2daaa82cfcb0e9b9f130b10833f4b154dd105e64b89f3613d44d85469a460d88L168-R176)
* Updated the tool execution flow in `ConversationSession+ExecuteOnce.swift` to handle success and failure cases explicitly, updating tool status accordingly.

### UI and Feedback Improvements:
* Added new UI states (`running`, `failed`) to `ToolHintView` to visually represent tool execution progress and outcomes. [[1]](diffhunk://#diff-4d355d4eec072edc7189047cf0ed974c83819d1327b5a897e7b9dcc61b9eff99R95-R99) [[2]](diffhunk://#diff-4d355d4eec072edc7189047cf0ed974c83819d1327b5a897e7b9dcc61b9eff99R110-R120)
* Updated `MessageListView+Adapter.swift` to map tool status codes to the new `ToolHintView` states.

### Localization Updates:
* Added localized strings for new tool execution states (`running` and `failed`) in `Localizable.xcstrings`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tool execution feedback with explicit running, success, and failure states displayed in the user interface.
  * Tool call status now updates in real-time, providing clearer progress and error messages.

* **Bug Fixes**
  * Enhanced error handling for tool execution, ensuring users receive accurate feedback on failures.

* **Localization**
  * Added new Chinese translations for tool execution status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->