### PR TITLE
添加xcconfig 配置证书相关信息

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ xcuserdata/
 yarn-debug.log*
 yarn-error.log*
 
+FlowDown/Configuration/Developer.xcconfig

--- a/FlowDown.xcodeproj/project.pbxproj
+++ b/FlowDown.xcodeproj/project.pbxproj
@@ -106,6 +106,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		3C2409992E97803B0055F162 /* Configuration */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Configuration;
+			sourceTree = "<group>";
+		};
 		5050EB812D478A5800634B81 /* Backend */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Backend;
@@ -257,6 +262,7 @@
 		50B5145B2D2305890092284C /* FlowDown */ = {
 			isa = PBXGroup;
 			children = (
+				3C2409992E97803B0055F162 /* Configuration */,
 				50B5146A2D2305F20092284C /* main.swift */,
 				50B514652D2305C00092284C /* Application */,
 				5050EB812D478A5800634B81 /* Backend */,
@@ -541,13 +547,17 @@
 /* Begin XCBuildConfiguration section */
 		50343FEE2DA2515C00CC6820 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 3C2409992E97803B0055F162 /* Configuration */;
+			baseConfigurationReferenceRelativePath = BaseConfig.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "FlowDown/Resources/Entitlements/Entitlements-Catalyst.entitlements";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = 409;
+				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_ENHANCED_SECURITY = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -583,7 +593,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.5;
-				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.fdp;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = FlowDown;
 				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
 				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
@@ -604,14 +614,17 @@
 		};
 		50343FEF2DA2515C00CC6820 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 3C2409992E97803B0055F162 /* Configuration */;
+			baseConfigurationReferenceRelativePath = BaseConfig.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "FlowDown/Resources/Entitlements/Entitlements-Catalyst.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = 409;
+				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_ENHANCED_SECURITY = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -647,7 +660,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.5;
-				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.flow;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = FlowDown;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
@@ -660,6 +673,7 @@
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				SWIFT_VERSION = 5.0;
@@ -669,13 +683,17 @@
 		};
 		503498D12D23053E004672BD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 3C2409992E97803B0055F162 /* Configuration */;
+			baseConfigurationReferenceRelativePath = BaseConfig.xcconfig;
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "FlowDown/Resources/Entitlements/Entitlements-iOS.entitlements";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = 409;
+				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_ENHANCED_SECURITY = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -711,7 +729,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.5;
-				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.fdp;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -727,14 +745,17 @@
 		};
 		503498D22D23053E004672BD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 3C2409992E97803B0055F162 /* Configuration */;
+			baseConfigurationReferenceRelativePath = BaseConfig.xcconfig;
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "FlowDown/Resources/Entitlements/Entitlements-iOS.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = 409;
+				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_ENHANCED_SECURITY = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -770,13 +791,14 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.5;
-				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.flow;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_ENABLE_EXPLICIT_MODULES = YES;
 				SWIFT_STRICT_CONCURRENCY = minimal;

--- a/FlowDown/Configuration/BaseConfig.xcconfig
+++ b/FlowDown/Configuration/BaseConfig.xcconfig
@@ -1,0 +1,25 @@
+//
+//  BaseConfig.xcconfig
+//  FlowDown
+//
+//  Created by king on 2025/10/9.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+CODE_SIGN_IDENTITY = Apple Development
+CODE_SIGN_STYLE = Automatic
+DEVELOPMENT_TEAM = 964G86XT2P
+PRODUCT_BUNDLE_IDENTIFIER[config=Debug][sdk=*][arch=*] = wiki.qaq.fdp
+PRODUCT_BUNDLE_IDENTIFIER[config=Release][sdk=*][arch=*] = wiki.qaq.flow
+
+
+ENABLE_SANDBOX_CHECK = 1
+ENABLE_SANDBOX_CHECK_0 =
+ENABLE_SANDBOX_CHECK_1 = ENABLE_SANDBOX_CHECK
+ENABLE_SANDBOX_CHECK_COMPILATION_CONDITIONS = $(ENABLE_SANDBOX_CHECK_$(ENABLE_SANDBOX_CHECK))
+
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) $(ENABLE_SANDBOX_CHECK_COMPILATION_CONDITIONS)
+
+#include? "Developer.xcconfig"

--- a/FlowDown/main.swift
+++ b/FlowDown/main.swift
@@ -20,7 +20,7 @@
     }
 #endif
 
-#if os(macOS) || targetEnvironment(macCatalyst)
+#if (os(macOS) || targetEnvironment(macCatalyst)) && ENABLE_SANDBOX_CHECK
     do {
         // make sure sandbox is enabled otherwise panic the app
         let sandboxTestDir = URL(fileURLWithPath: "/tmp/sandbox.test.\(UUID().uuidString)")

--- a/Resources/DevKit/scripts/archive.all.sh
+++ b/Resources/DevKit/scripts/archive.all.sh
@@ -14,6 +14,7 @@ else
 fi
 
 PROJECT_ROOT=$(pwd)
+DEVELOPER_LOCAL_XCCONFIG=$PROJECT_ROOT/FlowDown/Configuration/Developer.xcconfig
 
 if [[ -n $(git status --porcelain) ]]; then
     echo "[!] git is not clean"
@@ -25,6 +26,11 @@ git add -A
 git commit -m "Archive Commit $(date)"
 
 ./Resources/DevKit/scripts/scan.license.sh
+
+if [[ ! -f "${DEVELOPER_LOCAL_XCCONFIG}" ]]; then
+    echo "[*] create empty Developer.xcconfig"
+    echo "" >> $DEVELOPER_LOCAL_XCCONFIG
+fi
 
 xcodebuild -workspace FlowDown.xcworkspace \
     -scheme FlowDown \


### PR DESCRIPTION
* 为了减少工程文件的冲突，改用xcconfig配置文件来配置证书相关的信息
* 同时也支持了本地无证书场景下的运行，需要创建`FlowDown/Configuration/Developer.xcconfig`文件, 内容如下

```
CODE_SIGN_IDENTITY = 
CODE_SIGN_STYLE = Manual
DEVELOPMENT_TEAM =
ENABLE_SANDBOX_CHECK = 0
```