### PR TITLE
优化会话/消息删除逻辑

### DIFF
--- a/Frameworks/Storage/Sources/Storage/Storage/Storage+Attachment.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage+Attachment.swift
@@ -90,11 +90,14 @@ public extension Storage {
 
         try runTransaction(handle: handle) { [weak self] in
             guard let self else { return }
+
             let object: Attachment? = try $0.getObject(fromTable: Attachment.tableName, where: Attachment.Properties.messageId == messageId)
+
             guard let object else {
                 return
             }
 
+            object.removed = true
             object.markModified()
 
             let update = StatementUpdate().update(table: Attachment.tableName)
@@ -117,7 +120,13 @@ public extension Storage {
 
         try runTransaction(handle: handle) { [weak self] in
             guard let self else { return }
-            let objects: [Attachment] = try $0.getObjects(fromTable: Attachment.tableName, where: Attachment.Properties.messageId.in(messageIds))
+
+            let objects: [Attachment] = try $0.getObjects(
+                fromTable: Attachment.tableName,
+                where: Attachment.Properties.messageId.in(messageIds)
+                    && Attachment.Properties.removed == false
+            )
+
             guard !objects.isEmpty else {
                 return
             }
@@ -149,7 +158,12 @@ public extension Storage {
     func attachmentsMarkDelete(skipSync: Bool = false, handle: Handle? = nil) throws {
         try runTransaction(handle: handle) { [weak self] in
             guard let self else { return }
-            let objects: [Attachment] = try $0.getObjects(fromTable: Attachment.tableName, where: Attachment.Properties.removed == false)
+
+            let objects: [Attachment] = try $0.getObjects(
+                fromTable: Attachment.tableName,
+                where: Attachment.Properties.removed == false
+            )
+
             guard !objects.isEmpty else {
                 return
             }

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage.swift
@@ -105,7 +105,9 @@ public class Storage {
         try setup(db: db)
 
         // 将上传中/上传失败的同步记录重置为Pending
-        try pendingUploadRestToPendingState()
+        try db.run(transaction: { [unowned self] in
+            try pendingUploadRestToPendingState(handle: $0)
+        })
     }
 
     func setup(db: Database) throws {


### PR DESCRIPTION
删除会话/消息时还是需要生成对应消息/附件的删除同步事件，减少云端数据残留