### PR TITLE
优化DB ORM对象字段写入方式

### DIFF
--- a/FlowDown/Backend/ChatTemplate/ChatTemplateManager.swift
+++ b/FlowDown/Backend/ChatTemplate/ChatTemplateManager.swift
@@ -84,9 +84,9 @@ class ChatTemplateManager {
     func createConversationFromTemplate(_ template: ChatTemplate) -> Conversation.ID {
         assert(Thread.isMainThread)
         let conversation = ConversationManager.shared.createNewConversation {
-            $0.icon = template.avatar
-            $0.title = template.name
-            $0.shouldAutoRename = true
+            $0.update(\.icon, to: template.avatar)
+            $0.update(\.title, to: template.name)
+            $0.update(\.shouldAutoRename, to: true)
         }
 
         let session = ConversationSessionManager.shared.session(for: conversation.id)

--- a/FlowDown/Backend/Conversation/ConversationManager+CRUD.swift
+++ b/FlowDown/Backend/Conversation/ConversationManager+CRUD.swift
@@ -34,9 +34,9 @@ extension ConversationManager {
 
     func createNewConversation(_ block: Storage.ConversationMakeInitDataBlock? = nil) -> Conversation {
         let tempObject = sdb.conversationMake {
-            $0.title = String(localized: "Conversation")
+            $0.update(\.title, to: String(localized: "Conversation"))
             if $0.modelId?.isEmpty ?? true {
-                $0.modelId = ModelManager.ModelIdentifier.defaultModelForConversation
+                $0.update(\.modelId, to: ModelManager.ModelIdentifier.defaultModelForConversation)
             }
 
             if let block {
@@ -81,9 +81,11 @@ extension ConversationManager {
                 session.notifyMessagesDidChange()
 
                 editConversation(identifier: object.id) { conversation in
-                    conversation.title = String(localized: "Introduction to FlowDown")
-                    conversation.icon = "🥳".textToImage(size: 128)?.pngData() ?? .init()
-                    conversation.shouldAutoRename = false
+                    let icon = "🥳".textToImage(size: 128)?.pngData() ?? .init()
+
+                    conversation.update(\.title, to: String(localized: "Introduction to FlowDown"))
+                    conversation.update(\.icon, to: icon)
+                    conversation.update(\.shouldAutoRename, to: false)
                 }
 
                 ConversationManager.shouldShowGuideMessage = false
@@ -106,18 +108,18 @@ extension ConversationManager {
         let conv = conversation(identifier: identifier)
         guard var conv else { return }
         block(&conv)
-        conv.markModified()
         sdb.conversationUpdate(object: conv)
         scanAll()
     }
 
     func duplicateConversation(identifier: Conversation.ID) -> Conversation.ID? {
         let ans = sdb.conversationDuplicate(identifier: identifier) { conv in
-            conv.creation = .init()
-            conv.title = String(
+            let title = String(
                 format: String(localized: "%@ Copy"),
                 conv.title
             )
+
+            conv.update(\.title, to: title)
         }
         scanAll()
         return ans

--- a/FlowDown/Backend/Conversation/ConversationManager+Compress.swift
+++ b/FlowDown/Backend/Conversation/ConversationManager+Compress.swift
@@ -50,9 +50,10 @@ extension ConversationManager {
         completion: @escaping (Result<Conversation.ID, Error>) -> Void
     ) {
         let conv = ConversationManager.shared.createNewConversation {
-            $0.title = title
-            $0.icon = "🗜️".textToImage(size: 64)?.pngData() ?? .init()
-            $0.shouldAutoRename = true
+            let icon = "🗜️".textToImage(size: 64)?.pngData() ?? .init()
+            $0.update(\.title, to: title)
+            $0.update(\.icon, to: icon)
+            $0.update(\.shouldAutoRename, to: true)
         }
         let sess = ConversationSessionManager.shared.session(for: conv.id)
 

--- a/FlowDown/Backend/Conversation/ConversationManager+Menu.swift
+++ b/FlowDown/Backend/Conversation/ConversationManager+Menu.swift
@@ -51,8 +51,8 @@ extension ConversationManager {
                     ) { text in
                         guard !text.isEmpty else { return }
                         ConversationManager.shared.editConversation(identifier: conv.id) {
-                            $0.title = text
-                            $0.shouldAutoRename = false
+                            $0.update(\.title, to: text)
+                            $0.update(\.shouldAutoRename, to: false)
                         }
                     }
                     controller.present(alert, animated: true)
@@ -63,8 +63,9 @@ extension ConversationManager {
                 ) { _ in
                     let picker = EmojiPickerViewController(sourceView: view) { emoji in
                         ConversationManager.shared.editConversation(identifier: conv.id) {
-                            $0.icon = emoji.emoji.textToImage(size: 128)?.pngData() ?? .init()
-                            $0.shouldAutoRename = false
+                            let icon = emoji.emoji.textToImage(size: 128)?.pngData() ?? .init()
+                            $0.update(\.icon, to: icon)
+                            $0.update(\.shouldAutoRename, to: false)
                         }
                     }
                     controller.present(picker, animated: true)
@@ -217,7 +218,8 @@ extension ConversationManager {
                             let session = sessionManager.session(for: conv.id)
                             if let emoji = await session.generateConversationIcon() {
                                 ConversationManager.shared.editConversation(identifier: conv.id) { conversation in
-                                    conversation.icon = emoji.textToImage(size: 128)?.pngData() ?? .init()
+                                    let icon = emoji.textToImage(size: 128)?.pngData() ?? .init()
+                                    conversation.update(\.icon, to: icon)
                                 }
                             } else {
                                 Indicator.present(
@@ -246,7 +248,7 @@ extension ConversationManager {
                             let session = sessionManager.session(for: conv.id)
                             if let title = await session.generateConversationTitle() {
                                 ConversationManager.shared.editConversation(identifier: conv.id) { conversation in
-                                    conversation.title = title
+                                    conversation.update(\.title, to: title)
                                 }
                             } else {
                                 Indicator.present(
@@ -273,7 +275,7 @@ extension ConversationManager {
                         image: UIImage(systemName: "star.slash")
                     ) { _ in
                         ConversationManager.shared.editConversation(identifier: conv.id) {
-                            $0.isFavorite = false
+                            $0.update(\.isFavorite, to: false)
                         }
                     }
                 } else {
@@ -287,7 +289,7 @@ extension ConversationManager {
                         image: UIImage(systemName: "star")
                     ) { _ in
                         ConversationManager.shared.editConversation(identifier: conv.id) {
-                            $0.isFavorite = true
+                            $0.update(\.isFavorite, to: true)
                         }
                     }
                 } else {
@@ -478,7 +480,7 @@ extension ConversationManager {
                                         attributes: .destructive
                                     ) { _ in
                                         ConversationManager.shared.editConversation(identifier: conv.id) {
-                                            $0.icon = .init()
+                                            $0.update(\.icon, to: .init())
                                         }
                                     }
                                 } else { nil }

--- a/FlowDown/Backend/Conversation/Session/ConversationSession.swift
+++ b/FlowDown/Backend/Conversation/Session/ConversationSession.swift
@@ -40,7 +40,7 @@ final class ConversationSession: Identifiable {
         get { ConversationManager.shared.conversation(identifier: id)?.shouldAutoRename ?? false }
         set {
             ConversationManager.shared.editConversation(identifier: id) { conv in
-                conv.shouldAutoRename = newValue
+                conv.update(\.shouldAutoRename, to: newValue)
             }
         }
     }
@@ -101,7 +101,6 @@ final class ConversationSession: Identifiable {
             }
 
             $0.update(\.role, to: role)
-            $0.update(\.creation, to: .now)
         }
 
         messages.append(message)

--- a/FlowDown/Backend/Conversation/Session/PostAction/ConversationSession+Rename.swift
+++ b/FlowDown/Backend/Conversation/Session/PostAction/ConversationSession+Rename.swift
@@ -12,15 +12,16 @@ import Storage
 extension ConversationSession {
     func updateTitleAndIcon() async {
         if let title = await generateConversationTitle() {
-            ConversationManager.shared.editConversation(identifier: id) { conversation in
-                conversation.title = title
-                conversation.shouldAutoRename = false
+            ConversationManager.shared.editConversation(identifier: id) {
+                $0.update(\.title, to: title)
+                $0.update(\.shouldAutoRename, to: false)
             }
         }
         if let emoji = await generateConversationIcon() {
-            ConversationManager.shared.editConversation(identifier: id) { conversation in
-                conversation.icon = emoji.textToImage(size: 128)?.pngData() ?? .init()
-                conversation.shouldAutoRename = false
+            ConversationManager.shared.editConversation(identifier: id) {
+                let icon = emoji.textToImage(size: 128)?.pngData() ?? .init()
+                $0.update(\.icon, to: icon)
+                $0.update(\.shouldAutoRename, to: false)
             }
         }
     }

--- a/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+Images.swift
+++ b/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+Images.swift
@@ -95,7 +95,9 @@ extension ConversationSession {
         }
 
         let collapseAfterReasoningComplete = ModelManager.shared.collapseReasoningSectionWhenComplete
-        if collapseAfterReasoningComplete { message.update(\.isThinkingFold, to: true) }
+        if collapseAfterReasoningComplete {
+            message.update(\.isThinkingFold, to: true)
+        }
         stopThinking(for: message.objectId)
         await requestUpdate(view: currentMessageListView)
         await currentMessageListView.loading()

--- a/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+WebSearch.swift
+++ b/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+WebSearch.swift
@@ -503,7 +503,7 @@ extension ConversationSession {
         let webSearchMessage = appendNewMessage(role: .webSearch) {
             var status = $0.webSearchStatus
             status.queries = searchQueries
-            $0.update(\.webSearchStatus, to: status)
+            $0.assign(\.webSearchStatus, to: status)
         }
 
         await requestUpdate(view: currentMessageListView)
@@ -532,7 +532,7 @@ extension ConversationSession {
             }
             var updatedStatus = webSearchMessage.webSearchStatus
             updatedStatus.searchResults.append(contentsOf: storableContent)
-            webSearchMessage.update(\.webSearchStatus, to: updatedStatus)
+            webSearchMessage.assign(\.webSearchStatus, to: updatedStatus)
         }
 
         for try await phase in gatheringWebContent(
@@ -548,12 +548,12 @@ extension ConversationSession {
             status.currentQueryBeginDate = phase.queryBeginDate
             status.numberOfResults = phase.numberOfResults
             status.proccessProgress = max(0.1, phase.proccessProgress)
-            webSearchMessage.update(\.webSearchStatus, to: status)
+            webSearchMessage.assign(\.webSearchStatus, to: status)
             await requestUpdate(view: currentMessageListView)
         }
         var finalStatus = webSearchMessage.webSearchStatus
         finalStatus.proccessProgress = 0
-        webSearchMessage.update(\.webSearchStatus, to: finalStatus)
+        webSearchMessage.assign(\.webSearchStatus, to: finalStatus)
         await requestUpdate(view: currentMessageListView)
 
         object.attachments.append(contentsOf: webAttachments)
@@ -561,7 +561,7 @@ extension ConversationSession {
         if webAttachments.isEmpty {
             var errorStatus = webSearchMessage.webSearchStatus
             errorStatus.proccessProgress = -1
-            webSearchMessage.update(\.webSearchStatus, to: errorStatus)
+            webSearchMessage.assign(\.webSearchStatus, to: errorStatus)
             throw NSError(
                 domain: "Inference Service",
                 code: -1,

--- a/FlowDown/Backend/MCPService/MCPService.swift
+++ b/FlowDown/Backend/MCPService/MCPService.swift
@@ -177,10 +177,10 @@ class MCPService: NSObject {
 
     private func updateServerStatus(_ serverId: ModelContextServer.ID, status: ModelContextServer.ConnectionStatus) {
         // 连接状态不进行同步
-        edit(identifier: serverId, skipSync: true) { client in
-            client.connectionStatus = status
+        edit(identifier: serverId, skipSync: true) {
+            $0.update(\.connectionStatus, to: status)
             if status == .connected {
-                client.lastConnected = Date()
+                $0.update(\.lastConnected, to: .now)
             }
         }
     }
@@ -198,8 +198,8 @@ class MCPService: NSObject {
         }
 
         // capabilities不进行同步
-        edit(identifier: config.id, skipSync: true) { client in
-            client.capabilities = StringArrayCodable(discoveredCapabilities)
+        edit(identifier: config.id, skipSync: true) {
+            $0.assign(\.capabilities, to: StringArrayCodable(discoveredCapabilities))
         }
     }
 

--- a/FlowDown/Backend/ModelTools/MemoryTools/MemoryStore.swift
+++ b/FlowDown/Backend/ModelTools/MemoryTools/MemoryStore.swift
@@ -141,7 +141,6 @@ public class MemoryStore: ObservableObject {
                     }
 
                     existingMemory.update(\.content, to: trimmedContent)
-                    existingMemory.update(\.creation, to: Date.now)
                     try storage.updateMemory(existingMemory)
 
                     continuation.resume()
@@ -266,7 +265,6 @@ public class MemoryStore: ObservableObject {
             }
 
             existingMemory.update(\.content, to: trimmedContent)
-            existingMemory.update(\.creation, to: Date.now)
             try storage.updateMemory(existingMemory)
 
             return "Memory updated successfully."

--- a/FlowDown/Backend/ModelTools/Supplement/MTWebSearchTool.swift
+++ b/FlowDown/Backend/ModelTools/Supplement/MTWebSearchTool.swift
@@ -71,7 +71,7 @@ class MTWebSearchTool: ModelTool, @unchecked Sendable {
 
         var status = webSearchMessage.webSearchStatus
         status.queries = [query]
-        webSearchMessage.update(\.webSearchStatus, to: status)
+        webSearchMessage.assign(\.webSearchStatus, to: status)
 
         await session.requestUpdate(view: messageListView)
 
@@ -84,7 +84,7 @@ class MTWebSearchTool: ModelTool, @unchecked Sendable {
 
             var status = webSearchMessage.webSearchStatus
             status.searchResults.append(contentsOf: storableContent)
-            webSearchMessage.update(\.webSearchStatus, to: status)
+            webSearchMessage.assign(\.webSearchStatus, to: status)
         }
 
         for try await phase in await messageListView.session.gatheringWebContent(
@@ -99,13 +99,13 @@ class MTWebSearchTool: ModelTool, @unchecked Sendable {
             status.currentQueryBeginDate = phase.queryBeginDate
             status.numberOfResults = phase.numberOfResults
             status.proccessProgress = max(0.1, phase.proccessProgress)
-            webSearchMessage.update(\.webSearchStatus, to: status)
+            webSearchMessage.assign(\.webSearchStatus, to: status)
             await session.requestUpdate(view: messageListView)
         }
 
         var statusFinal = webSearchMessage.webSearchStatus
         statusFinal.proccessProgress = 1.0
-        webSearchMessage.update(\.webSearchStatus, to: statusFinal)
+        webSearchMessage.assign(\.webSearchStatus, to: statusFinal)
         await session.requestUpdate(view: messageListView)
 
         if webSearchResults.isEmpty {

--- a/FlowDown/Interface/Components/ChatView/ChatView+Delegates.swift
+++ b/FlowDown/Interface/Components/ChatView/ChatView+Delegates.swift
@@ -198,8 +198,8 @@ extension ChatView: RichEditorView.Delegate {
             anchoringView: anchor,
             currentSelection: modelIdentifier
         ) { modelIdentifier in
-            ConversationManager.shared.editConversation(identifier: conversationIdentifier) { conv in
-                conv.update(\.modelId, to: modelIdentifier)
+            ConversationManager.shared.editConversation(identifier: conversationIdentifier) {
+                $0.update(\.modelId, to: modelIdentifier)
             }
             if self.editorApplyModelToDefault {
                 ModelManager.ModelIdentifier.defaultModelForConversation = modelIdentifier
@@ -285,9 +285,9 @@ extension ChatView: RichEditorView.Delegate {
                         attributes: [.keepsMenuPresented],
                         state: server.isEnabled ? .on : .off
                     ) { action in
-                        MCPService.shared.edit(identifier: server.id) { server in
-                            server.isEnabled.toggle()
-                            action.state = server.isEnabled ? .on : .off
+                        MCPService.shared.edit(identifier: server.id) {
+                            $0.update(\.isEnabled, to: !$0.isEnabled)
+                            action.state = $0.isEnabled ? .on : .off
                         }
                     }
                 }

--- a/FlowDown/Interface/ViewController/SettingController/MCP/MCPEditorController/MCPEditorController.swift
+++ b/FlowDown/Interface/ViewController/SettingController/MCP/MCPEditorController/MCPEditorController.swift
@@ -144,8 +144,8 @@ class MCPEditorController: StackScrollController {
         let enabledView = ConfigurableToggleActionView()
         enabledView.boolValue = server.isEnabled
         enabledView.actionBlock = { value in
-            MCPService.shared.edit(identifier: self.serverId) { client in
-                client.isEnabled = value
+            MCPService.shared.edit(identifier: self.serverId) {
+                $0.update(\.isEnabled, to: value)
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 // let toggle finish animate
@@ -177,8 +177,8 @@ class MCPEditorController: StackScrollController {
                     title: String(localized: "Streamble HTTP"),
                     image: UIImage(systemName: "network")
                 ) { _ in
-                    MCPService.shared.edit(identifier: self.serverId) { client in
-                        client.type = .http
+                    MCPService.shared.edit(identifier: self.serverId) {
+                        $0.update(\.type, to: .http)
                     }
                     self.refreshUI()
                     view.configure(value: String(localized: "Streamble HTTP"))
@@ -201,8 +201,8 @@ class MCPEditorController: StackScrollController {
                 placeholder: placeholder,
                 text: server.endpoint.isEmpty ? "https://" : server.endpoint
             ) { output in
-                MCPService.shared.edit(identifier: self.serverId) { client in
-                    client.endpoint = output
+                MCPService.shared.edit(identifier: self.serverId) {
+                    $0.update(\.endpoint, to: output)
                 }
                 self.refreshUI()
                 view.configure(value: output.isEmpty ? String(localized: "Not Configured") : output)
@@ -228,8 +228,9 @@ class MCPEditorController: StackScrollController {
                 }
                 let jsonData = try? JSONSerialization.data(withJSONObject: object, options: .prettyPrinted)
                 let jsonString = String(data: jsonData ?? Data(), encoding: .utf8) ?? ""
-                MCPService.shared.edit(identifier: self.serverId) { client in
-                    client.header = jsonString == "{}" ? "" : jsonString
+                MCPService.shared.edit(identifier: self.serverId) {
+                    let header = jsonString == "{}" ? "" : jsonString
+                    $0.update(\.header, to: header)
                 }
                 self.refreshUI()
                 view.configure(value: object.isEmpty ? String(localized: "No Headers") : String(localized: "Configured"))
@@ -259,8 +260,8 @@ class MCPEditorController: StackScrollController {
                 placeholder: String(localized: "Nickname (Optional)"),
                 text: client.name
             ) { output in
-                MCPService.shared.edit(identifier: self.serverId) { server in
-                    server.name = output
+                MCPService.shared.edit(identifier: self.serverId) {
+                    $0.update(\.name, to: output)
                 }
                 self.refreshUI()
                 view.configure(value: output.isEmpty ? String(localized: "Not Configured") : output)

--- a/FlowDown/Interface/ViewController/SettingController/Model/ModelController/ModelController+Delegates.swift
+++ b/FlowDown/Interface/ViewController/SettingController/Model/ModelController/ModelController+Delegates.swift
@@ -73,7 +73,7 @@ extension SettingController.SettingContent.ModelController: UITableViewDelegate 
                     guard let model = ModelManager.shared.cloudModel(identifier: itemIdentifier.identifier) else {
                         return
                     }
-                    model.objectId = UUID().uuidString
+                    model.update(\.objectId, to: UUID().uuidString)
                     ModelManager.shared.insertCloudModel(model)
                 }
             })

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage+Attachment.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage+Attachment.swift
@@ -29,6 +29,9 @@ public extension Storage {
             block(attachment)
         }
 
+        attachment.creation = .now
+        attachment.modified = attachment.creation
+
         if skipSave {
             return attachment
         }

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage+CloudModel.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage+CloudModel.swift
@@ -83,7 +83,6 @@ public extension Storage {
         )
         guard var object = read else { return }
         block(&object)
-        object.markModified()
         try? cloudModelPut(objects: [object])
     }
 

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage+Memory.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage+Memory.swift
@@ -158,7 +158,6 @@ public extension Storage {
                 throw MemoryError.memoryNotFound(memory.objectId)
             }
 
-            memory.markModified()
             try db.insertOrReplace([memory], intoTable: Memory.tableName)
             try pendingUploadEnqueue(sources: [(memory, .update)])
 

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage+Message.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage+Message.swift
@@ -18,6 +18,9 @@ public extension Storage {
             block(message)
         }
 
+        message.creation = .now
+        message.modified = message.creation
+
         if skipSave {
             return message
         }
@@ -117,17 +120,6 @@ public extension Storage {
         Task {
             try? await syncEngine?.sendChanges()
         }
-    }
-
-    func messageEdit(identifier: Message.ID, _ block: @escaping (inout Message) -> Void) {
-        let read: Message? = try? db.getObject(
-            fromTable: Message.tableName,
-            where: Message.Properties.objectId == identifier
-        )
-        guard var object = read else { return }
-        block(&object)
-        object.markModified()
-        messagePut(messages: [object])
     }
 
     func conversationIdentifierLookup(identifier: Message.ID) -> Conversation.ID? {

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage+ModelContextClient.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage+ModelContextClient.swift
@@ -28,6 +28,9 @@ public extension Storage {
             block(object)
         }
 
+        object.creation = .now
+        object.modified = object.creation
+
         try? runTransaction {
             try $0.insert([object], intoTable: ModelContextServer.tableName)
             try self.pendingUploadEnqueue(sources: [(object, .insert)], handle: $0)
@@ -99,7 +102,6 @@ public extension Storage {
         )
         guard var object = read else { return }
         block(&object)
-        object.markModified()
         modelContextServerPut(objects: [object], skipSync: skipSync)
     }
 

--- a/Frameworks/Storage/Sources/Storage/Sync/Updatable.swift
+++ b/Frameworks/Storage/Sources/Storage/Sync/Updatable.swift
@@ -7,15 +7,48 @@
 
 import Foundation
 
+/// 为支持通过 KeyPath 进行统一修改和差异检测的实体提供统一接口。
+///
+/// `Updatable` 允许安全地通过 KeyPath 修改对象属性，并在属性值变化时执行额外逻辑（例如标记为已修改）。
+/// - `update` 方法：仅当新值与旧值不相等时执行赋值并返回 `true`。
+/// - `assign` 方法：无条件赋值，不比较旧值。
+///
+/// ⚠️ 注意：
+/// - 仅当 `KeyPath` 是 `ReferenceWritableKeyPath`（可写引用）时才允许修改；
+/// - 对只读 KeyPath 调用 `update` / `assign` 时会触发断言失败（不会崩溃，但在 Debug 模式下提示）。
 public protocol Updatable: AnyObject {
+    /// 当值类型支持 `Equatable` 时，仅在值发生变化时更新。
+    /// - Parameters:
+    ///   - keyPath: 要更新的属性 KeyPath。
+    ///   - newValue: 新值。
+    /// - Returns: 若更新生效（值有变化）则返回 `true`。
+    @discardableResult
+    func update<Value: Equatable>(_ keyPath: KeyPath<Self, Value>, to newValue: Value) -> Bool
+
+    /// 当值类型支持 `Equatable` 时，仅在值发生变化时更新。
+    /// - Parameters:
+    ///   - keyPath: 可写 KeyPath。
+    ///   - newValue: 新值。
+    /// - Returns: 若更新生效（值有变化）则返回 `true`。
     @discardableResult
     func update<Value: Equatable>(_ keyPath: ReferenceWritableKeyPath<Self, Value>, to newValue: Value) -> Bool
 
-    @discardableResult
-    func update<Value: Equatable>(_ keyPath: KeyPath<Self, Value>, to newValue: Value) -> Bool
+    /// 无条件为属性赋新值（即使新旧值相同）。
+    /// - Parameters:
+    ///   - keyPath: 属性的 KeyPath。
+    ///   - newValue: 要赋的新值。
+    func assign<Value>(_ keyPath: KeyPath<Self, Value>, to newValue: Value)
+
+    /// 无条件为属性赋新值（即使新旧值相同）。
+    /// - Parameters:
+    ///   - keyPath: 可写属性的 KeyPath。
+    ///   - newValue: 要赋的新值。
+    func assign<Value>(_ keyPath: ReferenceWritableKeyPath<Self, Value>, to newValue: Value)
 }
 
 public extension Updatable {
+    /// 对只读 KeyPath 的 `update` 调用时自动进行安全检查。
+    /// 若 KeyPath 不可写，会触发断言提示。
     @discardableResult
     func update<Value: Equatable>(_ keyPath: KeyPath<Self, Value>, to newValue: Value) -> Bool {
         guard let writable = keyPath as? ReferenceWritableKeyPath<Self, Value> else {
@@ -23,5 +56,15 @@ public extension Updatable {
             return false
         }
         return update(writable, to: newValue)
+    }
+
+    /// 对只读 KeyPath 的 `assign` 调用时自动进行安全检查。
+    /// 若 KeyPath 不可写，会触发断言提示。
+    func assign<Value>(_ keyPath: KeyPath<Self, Value>, to newValue: Value) {
+        guard let writable = keyPath as? ReferenceWritableKeyPath<Self, Value> else {
+            assertionFailure("❌ Attempted to assign to a read-only keyPath: \(keyPath)")
+            return
+        }
+        assign(writable, to: newValue)
     }
 }

--- a/Frameworks/Storage/Sources/Storage/Tables/Attachment.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/Attachment.swift
@@ -85,9 +85,13 @@ extension Attachment: Updatable {
     public func update<Value: Equatable>(_ keyPath: ReferenceWritableKeyPath<Attachment, Value>, to newValue: Value) -> Bool {
         let oldValue = self[keyPath: keyPath]
         guard oldValue != newValue else { return false }
+        assign(keyPath, to: newValue)
+        return true
+    }
+
+    public func assign<Value>(_ keyPath: ReferenceWritableKeyPath<Attachment, Value>, to newValue: Value) {
         self[keyPath: keyPath] = newValue
         markModified()
-        return true
     }
 
     package func update(_ block: (Attachment) -> Void) {

--- a/Frameworks/Storage/Sources/Storage/Tables/CloudModel.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/CloudModel.swift
@@ -15,27 +15,27 @@ public final class CloudModel: Identifiable, Codable, Equatable, Hashable, Table
         objectId
     }
 
-    public var objectId: String = UUID().uuidString
-    public var deviceId: String = Storage.deviceId
-    public var model_identifier: String = ""
-    public var model_list_endpoint: String = ""
-    public var creation: Date = .now
-    public var modified: Date = .now
-    public var removed: Bool = false
-    public var endpoint: String = ""
-    public var token: String = ""
-    public var headers: [String: String] = [:] // additional headers
-    public var capabilities: Set<ModelCapabilities> = []
-    public var context: ModelContextLength = .short_8k
-    public var temperature_preference: ModelTemperaturePreference = .inherit
-    public var temperature_override: Double?
+    public package(set) var objectId: String = UUID().uuidString
+    public package(set) var deviceId: String = Storage.deviceId
+    public package(set) var model_identifier: String = ""
+    public package(set) var model_list_endpoint: String = ""
+    public package(set) var creation: Date = .now
+    public package(set) var modified: Date = .now
+    public package(set) var removed: Bool = false
+    public package(set) var endpoint: String = ""
+    public package(set) var token: String = ""
+    public package(set) var headers: [String: String] = [:] // additional headers
+    public package(set) var capabilities: Set<ModelCapabilities> = []
+    public package(set) var context: ModelContextLength = .short_8k
+    public package(set) var temperature_preference: ModelTemperaturePreference = .inherit
+    public package(set) var temperature_override: Double?
 
     // can be used when loading model from our server
     // present to user on the top of the editor page
-    public var comment: String = ""
+    public package(set) var comment: String = ""
 
     // custom display name for the model
-    public var name: String = ""
+    public package(set) var name: String = ""
 
     public enum CodingKeys: String, CodingTableKey {
         public typealias Root = CloudModel
@@ -168,9 +168,13 @@ extension CloudModel: Updatable {
     public func update<Value: Equatable>(_ keyPath: ReferenceWritableKeyPath<CloudModel, Value>, to newValue: Value) -> Bool {
         let oldValue = self[keyPath: keyPath]
         guard oldValue != newValue else { return false }
+        assign(keyPath, to: newValue)
+        return true
+    }
+
+    public func assign<Value>(_ keyPath: ReferenceWritableKeyPath<CloudModel, Value>, to newValue: Value) {
         self[keyPath: keyPath] = newValue
         markModified()
-        return true
     }
 
     package func update(_ block: (CloudModel) -> Void) {

--- a/Frameworks/Storage/Sources/Storage/Tables/Conversation.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/Conversation.swift
@@ -11,17 +11,17 @@ public final class Conversation: Identifiable, Codable, TableNamed, DeviceOwned,
         objectId
     }
 
-    public var title: String = ""
-    public var creation: Date = .now
-    public var icon: Data = .init()
-    public var isFavorite: Bool = false
-    public var shouldAutoRename: Bool = true
-    public var modelId: String? = nil
+    public package(set) var title: String = ""
+    public package(set) var creation: Date = .now
+    public package(set) var icon: Data = .init()
+    public package(set) var isFavorite: Bool = false
+    public package(set) var shouldAutoRename: Bool = true
+    public package(set) var modelId: String? = nil
 
-    public var objectId: String = UUID().uuidString
-    public var deviceId: String = ""
-    public var removed: Bool = false
-    public var modified: Date = .init()
+    public package(set) var objectId: String = UUID().uuidString
+    public package(set) var deviceId: String = ""
+    public package(set) var removed: Bool = false
+    public package(set) var modified: Date = .init()
 
     public enum CodingKeys: String, CodingTableKey {
         public typealias Root = Conversation
@@ -70,9 +70,13 @@ extension Conversation: Updatable {
     public func update<Value: Equatable>(_ keyPath: ReferenceWritableKeyPath<Conversation, Value>, to newValue: Value) -> Bool {
         let oldValue = self[keyPath: keyPath]
         guard oldValue != newValue else { return false }
+        assign(keyPath, to: newValue)
+        return true
+    }
+
+    public func assign<Value>(_ keyPath: ReferenceWritableKeyPath<Conversation, Value>, to newValue: Value) {
         self[keyPath: keyPath] = newValue
         markModified()
-        return true
     }
 
     package func update(_ block: (Conversation) -> Void) {

--- a/Frameworks/Storage/Sources/Storage/Tables/Memory.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/Memory.swift
@@ -68,9 +68,13 @@ extension Memory: Updatable {
     public func update<Value: Equatable>(_ keyPath: ReferenceWritableKeyPath<Memory, Value>, to newValue: Value) -> Bool {
         let oldValue = self[keyPath: keyPath]
         guard oldValue != newValue else { return false }
+        assign(keyPath, to: newValue)
+        return true
+    }
+
+    public func assign<Value>(_ keyPath: ReferenceWritableKeyPath<Memory, Value>, to newValue: Value) {
         self[keyPath: keyPath] = newValue
         markModified()
-        return true
     }
 
     package func update(_ block: (Memory) -> Void) {

--- a/Frameworks/Storage/Sources/Storage/Tables/Message.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/Message.swift
@@ -97,9 +97,13 @@ extension Message: Updatable {
     public func update<Value: Equatable>(_ keyPath: ReferenceWritableKeyPath<Message, Value>, to newValue: Value) -> Bool {
         let oldValue = self[keyPath: keyPath]
         guard oldValue != newValue else { return false }
+        assign(keyPath, to: newValue)
+        return true
+    }
+
+    public func assign<Value>(_ keyPath: ReferenceWritableKeyPath<Message, Value>, to newValue: Value) {
         self[keyPath: keyPath] = newValue
         markModified()
-        return true
     }
 
     package func update(_ block: (Message) -> Void) {
@@ -158,7 +162,7 @@ public extension Message {
 }
 
 public extension Message {
-    struct WebSearchStatus: Codable, ColumnCodable, Hashable, Equatable {
+    struct WebSearchStatus: Codable, ColumnCodable, Hashable {
         public var id: UUID = .init()
 
         public var queries: [String] = []

--- a/Frameworks/Storage/Sources/Storage/Tables/ModelContextServer.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/ModelContextServer.swift
@@ -39,25 +39,25 @@ public final class ModelContextServer: Identifiable, Codable, TableNamed, Device
         objectId
     }
 
-    public var objectId: String = UUID().uuidString
-    public var deviceId: String = Storage.deviceId
-    public var name: String = ""
-    public var comment: String = ""
-    public var type: ServerType = .http
-    public var endpoint: String = ""
-    public var header: String = ""
-    public var timeout: Int = 60
-    public var isEnabled: Bool = true
-    public var toolsEnabled: EnableCodable = .init()
-    public var resourcesEnabled: EnableCodable = .init()
-    public var templateEnabled: EnableCodable = .init()
-    public var lastConnected: Date?
-    public var connectionStatus: ConnectionStatus = .disconnected
-    public var capabilities: StringArrayCodable = .init([])
+    public package(set) var objectId: String = UUID().uuidString
+    public package(set) var deviceId: String = Storage.deviceId
+    public package(set) var name: String = ""
+    public package(set) var comment: String = ""
+    public package(set) var type: ServerType = .http
+    public package(set) var endpoint: String = ""
+    public package(set) var header: String = ""
+    public package(set) var timeout: Int = 60
+    public package(set) var isEnabled: Bool = true
+    public package(set) var toolsEnabled: EnableCodable = .init()
+    public package(set) var resourcesEnabled: EnableCodable = .init()
+    public package(set) var templateEnabled: EnableCodable = .init()
+    public package(set) var lastConnected: Date?
+    public package(set) var connectionStatus: ConnectionStatus = .disconnected
+    public package(set) var capabilities: StringArrayCodable = .init([])
 
-    public var removed: Bool = false
-    public var creation: Date = .now
-    public var modified: Date = .now
+    public package(set) var removed: Bool = false
+    public package(set) var creation: Date = .now
+    public package(set) var modified: Date = .now
 
     public enum CodingKeys: String, CodingTableKey {
         public typealias Root = ModelContextServer
@@ -175,9 +175,13 @@ extension ModelContextServer: Updatable {
     public func update<Value: Equatable>(_ keyPath: ReferenceWritableKeyPath<ModelContextServer, Value>, to newValue: Value) -> Bool {
         let oldValue = self[keyPath: keyPath]
         guard oldValue != newValue else { return false }
+        assign(keyPath, to: newValue)
+        return true
+    }
+
+    public func assign<Value>(_ keyPath: ReferenceWritableKeyPath<ModelContextServer, Value>, to newValue: Value) {
         self[keyPath: keyPath] = newValue
         markModified()
-        return true
     }
 
     package func update(_ block: (ModelContextServer) -> Void) {
@@ -224,7 +228,7 @@ extension ModelContextServer: Equatable {
 extension ModelContextServer: Hashable {}
 
 public extension ModelContextServer {
-    enum ServerType: String, Codable, ColumnCodable {
+    enum ServerType: String, Codable, ColumnCodable, Equatable {
         case http
 
         public init?(with value: WCDBSwift.Value) {
@@ -241,7 +245,7 @@ public extension ModelContextServer {
         }
     }
 
-    enum ConnectionStatus: String, Codable, ColumnCodable {
+    enum ConnectionStatus: String, Codable, ColumnCodable, Equatable {
         case disconnected
         case connecting
         case connected


### PR DESCRIPTION
1. 限制外部只能通过 update/assign 更新ORM对象字段。减少DB层产生不必要同步事件