### PR TITLE
chore(i18n): update browser link labels

### DIFF
--- a/FlowDown/Interface/Components/MessageListView/Components/WebSearchStateView.swift
+++ b/FlowDown/Interface/Components/MessageListView/Components/WebSearchStateView.swift
@@ -82,7 +82,7 @@ final class WebSearchStateView: MessageListRowView {
                         parentViewController?.present(shareSheet, animated: true)
                     },
                     UIAction(
-                        title: String(localized: "Open in Safari"),
+                        title: String(localized: "Open in Default Browser"),
                         image: UIImage(systemName: "safari")
                     ) { [weak self] _ in
                         guard let self else { return }

--- a/FlowDown/Interface/Components/MessageListView/MessageListView.swift
+++ b/FlowDown/Interface/Components/MessageListView/MessageListView.swift
@@ -189,7 +189,7 @@ final class MessageListView: UIView {
                     )
                     self?.parentViewController?.present(shareSheet, animated: true)
                 },
-                UIAction(title: String(localized: "Open in Safari"), image: UIImage(systemName: "safari")) { [weak self] _ in
+                UIAction(title: String(localized: "Open in Default Browser"), image: UIImage(systemName: "safari")) { [weak self] _ in
                     guard let self else { return }
                     Indicator.open(link, referencedView: self)
                 },

--- a/FlowDown/Resources/Localizable.xcstrings
+++ b/FlowDown/Resources/Localizable.xcstrings
@@ -5071,12 +5071,12 @@
         }
       }
     },
-    "Open in Safari" : {
+    "Open in Default Browser" : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Safari 中打开"
+            "value" : "在默认浏览器中打开"
           }
         }
       }


### PR DESCRIPTION
Reason: Link actions were labeled “Open in Safari,” but the underlying logic already opens the user’s default browser, so the label could mislead users on non-Safari defaults.

Changes: Renamed the action title to “Open in Default Browser” everywhere it appears and updated the Simplified Chinese localization entry to match.

Result: Link menus now accurately communicate the behavior in both English and Simplified Chinese, avoiding confusion while keeping the existing browser-opening logic intact.