### PR TITLE
云端模型支持额外请求报文填写

### DIFF
--- a/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+ExecuteOnce.swift
+++ b/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+ExecuteOnce.swift
@@ -25,6 +25,7 @@ extension ConversationSession {
 
         let message = appendNewMessage(role: .assistant)
 
+        // Runtime additional body fields (merged with model's configured bodyFields)
         var additionalBodyField = [String: Any]()
         if let model = ModelManager.shared.cloudModel(identifier: modelID),
            URL(string: model.endpoint)?.host?.lowercased() == "openrouter.ai"

--- a/FlowDown/Interface/ViewController/Supplement/JsonEditorController.swift
+++ b/FlowDown/Interface/ViewController/Supplement/JsonEditorController.swift
@@ -1,0 +1,64 @@
+//
+//  JsonEditorController.swift
+//  FlowDown
+//
+//  Created by Willow Zhang on 10/31/25.
+//
+
+import AlertController
+import UIKit
+
+class JsonEditorController: CodeEditorController {
+    init(text: String) {
+        super.init(language: "json", text: text)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError()
+    }
+
+    override func done() {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            textView.text = "{}"
+            super.done()
+            return
+        }
+        guard let data = textView.text.data(using: .utf8) else {
+            let alert = AlertViewController(
+                title: "Error",
+                message: "Unable to decode text into data."
+            ) { context in
+                context.addAction(title: "OK", attribute: .accent) {
+                    context.dispose()
+                }
+            }
+            present(alert, animated: true)
+            return
+        }
+        do {
+            let object = try JSONSerialization.jsonObject(with: data)
+            // Ensure it's a dictionary (JSON object)
+            guard object is [String: Any] else {
+                throw NSError(
+                    domain: "JSONValidation",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: String(localized: "JSON must be an object (dictionary), not an array or primitive.")]
+                )
+            }
+            Logger.ui.infoFile("JsonEditorController done with valid JSON object")
+        } catch {
+            let alert = AlertViewController(
+                title: "Error",
+                message: "Unable to parse JSON: \(error.localizedDescription)"
+            ) { context in
+                context.addAction(title: "OK", attribute: .accent) {
+                    context.dispose()
+                }
+            }
+            present(alert, animated: true)
+            return
+        }
+        super.done()
+    }
+}

--- a/FlowDown/Resources/Localizable.xcstrings
+++ b/FlowDown/Resources/Localizable.xcstrings
@@ -331,6 +331,22 @@
         }
       }
     },
+    "Additional Body Fields (Optional)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Additional Body Fields (Optional)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "额外请求体字段（可选）"
+          }
+        }
+      }
+    },
     "Additional Header (Optional)" : {
       "localizations" : {
         "en" : {
@@ -2319,6 +2335,23 @@
         }
       }
     },
+    "Copy Link" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Link"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制链接"
+          }
+        }
+      }
+    },
     "Copy Message" : {
       "localizations" : {
         "en" : {
@@ -3547,6 +3580,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑"
+          }
+        }
+      }
+    },
+    "Edit Additional Body Fields" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Additional Body Fields"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑额外请求体字段"
           }
         }
       }
@@ -6357,6 +6406,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加入我们的 Discord 服务器。"
+          }
+        }
+      }
+    },
+    "JSON must be an object (dictionary), not an array or primitive." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON must be an object (dictionary), not an array or primitive."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 必须是对象（字典），不能是数组或基本类型。"
           }
         }
       }
@@ -11084,6 +11149,22 @@
         }
       }
     },
+    "This value will be added to the request body as additional fields. Accepts JSON." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This value will be added to the request body as additional fields. Accepts JSON."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此处的数据将会在请求额外添加到请求报文中，并覆盖已有的任何同名字段。使用 JSON。"
+          }
+        }
+      }
+    },
     "This value will be added to the request to distinguish the workgroup on the remote." : {
       "localizations" : {
         "en" : {
@@ -11707,6 +11788,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法打开链接。"
+          }
+        }
+      }
+    },
+    "Unable to parse JSON: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to parse JSON: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法解析 JSON：%@"
           }
         }
       }

--- a/Frameworks/Storage/Sources/Storage/Storage/DBMigration.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/DBMigration.swift
@@ -488,3 +488,22 @@ struct MigrationV2ToV3: DBMigration {
         Logger.database.info("[*] migrate version \(fromVersion.rawValue) -> \(toVersion.rawValue) end elapsed \(Int(elapsed), privacy: .public)ms")
     }
 }
+
+struct MigrationV3ToV4: DBMigration {
+    let fromVersion: DBVersion = .Version3
+    let toVersion: DBVersion = .Version4
+    let requiresDataMigration: Bool = false
+
+    func migrate(db: Database) throws {
+        let start = Date.now
+        Logger.database.info("[*] migrate version \(fromVersion.rawValue) -> \(toVersion.rawValue) begin")
+
+        // Add bodyFields column to CloudModel table
+        try db.create(table: CloudModel.tableName, of: CloudModel.self)
+
+        try db.exec(StatementPragma().pragma(.userVersion).to(toVersion.rawValue))
+
+        let elapsed = Date.now.timeIntervalSince(start) * 1000.0
+        Logger.database.info("[*] migrate version \(fromVersion.rawValue) -> \(toVersion.rawValue) end elapsed \(Int(elapsed), privacy: .public)ms")
+    }
+}

--- a/Frameworks/Storage/Sources/Storage/Storage/DBVersion.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/DBVersion.swift
@@ -10,4 +10,5 @@ enum DBVersion: Int, CaseIterable {
     case Version1 = 1
     case Version2 = 2
     case Version3 = 3
+    case Version4 = 4
 }

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage.swift
@@ -81,12 +81,14 @@ public class Storage {
                 MigrationV0ToV1(),
                 MigrationV1ToV2(deviceId: Storage.deviceId, requiresDataMigration: true),
                 MigrationV2ToV3(),
+                MigrationV3ToV4(),
             ]
         } else {
             initVersion = .Version1
             migrations = [
                 MigrationV1ToV2(deviceId: Storage.deviceId, requiresDataMigration: false),
                 MigrationV2ToV3(),
+                MigrationV3ToV4(),
             ]
         }
 

--- a/Frameworks/Storage/Sources/Storage/Tables/CloudModel.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/CloudModel.swift
@@ -25,6 +25,7 @@ public final class CloudModel: Identifiable, Codable, Equatable, Hashable, Table
     public package(set) var endpoint: String = ""
     public package(set) var token: String = ""
     public package(set) var headers: [String: String] = [:] // additional headers
+    public package(set) var bodyFields: String = "" // additional body fields as JSON string
     public package(set) var capabilities: Set<ModelCapabilities> = []
     public package(set) var context: ModelContextLength = .short_8k
     public package(set) var temperature_preference: ModelTemperaturePreference = .inherit
@@ -52,6 +53,7 @@ public final class CloudModel: Identifiable, Codable, Equatable, Hashable, Table
             BindColumnConstraint(endpoint, isNotNull: true, defaultTo: "")
             BindColumnConstraint(token, isNotNull: true, defaultTo: "")
             BindColumnConstraint(headers, isNotNull: true, defaultTo: [String: String]())
+            BindColumnConstraint(bodyFields, isNotNull: true, defaultTo: "")
             BindColumnConstraint(capabilities, isNotNull: true, defaultTo: Set<ModelCapabilities>())
             BindColumnConstraint(context, isNotNull: true, defaultTo: ModelContextLength.short_8k)
             BindColumnConstraint(comment, isNotNull: true, defaultTo: "")
@@ -71,6 +73,7 @@ public final class CloudModel: Identifiable, Codable, Equatable, Hashable, Table
         case endpoint
         case token
         case headers
+        case bodyFields
         case capabilities
         case context
         case comment
@@ -91,6 +94,7 @@ public final class CloudModel: Identifiable, Codable, Equatable, Hashable, Table
         endpoint: String = "",
         token: String = "",
         headers: [String: String] = [:],
+        bodyFields: String = "",
         context _: ModelContextLength = .medium_64k,
         capabilities: Set<ModelCapabilities> = [],
         comment: String = "",
@@ -107,6 +111,7 @@ public final class CloudModel: Identifiable, Codable, Equatable, Hashable, Table
         self.endpoint = endpoint
         self.token = token
         self.headers = headers
+        self.bodyFields = bodyFields
         self.capabilities = capabilities
         self.comment = comment
         self.name = name
@@ -125,6 +130,7 @@ public final class CloudModel: Identifiable, Codable, Equatable, Hashable, Table
         endpoint = try container.decodeIfPresent(String.self, forKey: .endpoint) ?? ""
         token = try container.decodeIfPresent(String.self, forKey: .token) ?? ""
         headers = try container.decodeIfPresent([String: String].self, forKey: .headers) ?? [:]
+        bodyFields = try container.decodeIfPresent(String.self, forKey: .bodyFields) ?? ""
         capabilities = try container.decodeIfPresent(Set<ModelCapabilities>.self, forKey: .capabilities) ?? []
         context = try container.decodeIfPresent(ModelContextLength.self, forKey: .context) ?? .short_8k
         comment = try container.decodeIfPresent(String.self, forKey: .comment) ?? ""
@@ -153,6 +159,7 @@ public final class CloudModel: Identifiable, Codable, Equatable, Hashable, Table
         hasher.combine(endpoint)
         hasher.combine(token)
         hasher.combine(headers)
+        hasher.combine(bodyFields)
         hasher.combine(capabilities)
         hasher.combine(context)
         hasher.combine(comment)


### PR DESCRIPTION
![CleanShot 2025-10-31 at 9  32 36@2x](https://github.com/user-attachments/assets/5fba8767-24c5-4606-ad4e-b8478af0d300)

额外的 body 填写，这样支持一些平台开启模型推理模式

例如 openrouter：
![CleanShot 2025-10-31 at 9  33 05@2x](https://github.com/user-attachments/assets/d9b249b8-f232-4e30-a790-9c50db21af85)

阿里云百炼：
![CleanShot 2025-10-31 at 9  33 58@2x](https://github.com/user-attachments/assets/ab4479e0-d817-47d3-b51e-42f0a60263be)
