### PR TITLE
Implement FlowDown issue 110

### DIFF
--- a/FlowDown/Backend/Conversation/ConversationManager+Compress.swift
+++ b/FlowDown/Backend/Conversation/ConversationManager+Compress.swift
@@ -98,6 +98,7 @@ extension ConversationManager {
                     input: messageBody
                 )
                 let mess = sess.appendNewMessage(role: .assistant)
+                mess.modelIdentifier = model
                 for try await resp in stream where !resp.content.isEmpty {
                     mess.update(\.document, to: resp.content)
                     sess.notifyMessagesDidChange()
@@ -108,12 +109,13 @@ extension ConversationManager {
                 await MainActor.run { completion(.success(conv.id)) }
             } catch {
                 await MainActor.run {
-                    sess.appendNewMessage(role: .assistant) {
+                    let message = sess.appendNewMessage(role: .assistant) {
                         $0.update(
                             \.document,
                             to: String(localized: "An error occurred during compression: \(error.localizedDescription)")
                         )
                     }
+                    message.modelIdentifier = model
                     sess.notifyMessagesDidChange()
                     sess.save()
                     completion(.failure(error))

--- a/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+Execute.swift
+++ b/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+Execute.swift
@@ -129,6 +129,7 @@ extension ConversationSession {
         } catch {
             logger.error("\(error.localizedDescription)")
             let errorMessage = appendNewMessage(role: .assistant)
+            errorMessage.modelIdentifier = modelID
             errorMessage.update(\.document, to: "*\(error.localizedDescription)*")
             await requestUpdate(view: currentMessageListView)
             await requestUpdate(view: currentMessageListView)

--- a/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+ExecuteOnce.swift
+++ b/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+ExecuteOnce.swift
@@ -24,6 +24,7 @@ extension ConversationSession {
         await currentMessageListView.loading()
 
         let message = appendNewMessage(role: .assistant)
+        message.modelIdentifier = modelID
 
         let stream = try await ModelManager.shared.streamingInfer(
             with: modelID,

--- a/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+Images.swift
+++ b/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+Images.swift
@@ -75,6 +75,7 @@ extension ConversationSession {
 
         var llmText = ""
         let message = appendNewMessage(role: .assistant)
+        message.modelIdentifier = decision
         for try await resp in try await ModelManager.shared.streamingInfer(
             with: decision,
             input: messages

--- a/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+WebSearch.swift
+++ b/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+WebSearch.swift
@@ -482,18 +482,20 @@ extension ConversationSession {
 
         if let required = searchRequired, !required {
             Logger.network.infoFile("model determined no web search is needed")
-            _ = appendNewMessage(role: .assistant) {
+            let message = appendNewMessage(role: .assistant) {
                 $0.update(\.document, to: String(localized: "I have determined that no web search is needed for this query."))
             }
+            message.modelIdentifier = models.auxiliary
             await requestUpdate(view: currentMessageListView)
             return
         }
 
         guard !searchQueries.isEmpty else {
             Logger.network.errorFile("failed to generate search queries")
-            _ = appendNewMessage(role: .assistant) {
+            let message = appendNewMessage(role: .assistant) {
                 $0.update(\.document, to: String(localized: "I was unable to generate appropriate search queries for this request."))
             }
+            message.modelIdentifier = models.auxiliary
             await requestUpdate(view: currentMessageListView)
             return
         }

--- a/FlowDown/Interface/Components/MessageListView/Components/AiMessageView.swift
+++ b/FlowDown/Interface/Components/MessageListView/Components/AiMessageView.swift
@@ -8,8 +8,25 @@ import MarkdownView
 import UIKit
 
 final class AiMessageView: MessageListRowView {
+    static let metadataSpacing: CGFloat = 6
+
+    private lazy var modelLabel: UILabel = .init()
     private(set) lazy var markdownView: MarkdownTextView = .init().with {
         $0.throttleInterval = 1 / 60
+    }
+
+    var modelName: String? {
+        didSet {
+            let trimmed = modelName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let trimmed, !trimmed.isEmpty {
+                modelLabel.text = trimmed
+                modelLabel.isHidden = false
+            } else {
+                modelLabel.text = nil
+                modelLabel.isHidden = true
+            }
+            setNeedsLayout()
+        }
     }
 
     var linkTapHandler: ((LinkPayload, NSRange, CGPoint) -> Void)? {
@@ -33,16 +50,39 @@ final class AiMessageView: MessageListRowView {
     }
 
     private func configureSubviews() {
+        modelLabel.textColor = .secondaryLabel
+        modelLabel.numberOfLines = 0
+        modelLabel.isHidden = true
+        contentView.addSubview(modelLabel)
         contentView.addSubview(markdownView)
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        modelName = nil
+    }
+
+    override func themeDidUpdate() {
+        super.themeDidUpdate()
+        modelLabel.font = theme.fonts.footnote
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        markdownView.frame = contentView.bounds
+        var markdownFrame = contentView.bounds
+
+        if !modelLabel.isHidden {
+            let availableWidth = markdownFrame.width
+            let size = modelLabel.sizeThatFits(.init(width: availableWidth, height: .greatestFiniteMagnitude))
+            let height = ceil(size.height)
+            modelLabel.frame = .init(x: 0, y: 0, width: availableWidth, height: height)
+            markdownFrame.origin.y += height + Self.metadataSpacing
+            markdownFrame.size.height = max(0, markdownFrame.height - height - Self.metadataSpacing)
+        } else {
+            modelLabel.frame = .zero
+        }
+
+        markdownView.frame = markdownFrame
         markdownView.bindContentOffset(from: nearestScrollView)
     }
 }

--- a/FlowDown/Interface/Components/MessageListView/MessageListView+Adapter.swift
+++ b/FlowDown/Interface/Components/MessageListView/MessageListView+Adapter.swift
@@ -113,7 +113,17 @@ extension MessageListView: ListViewAdapter {
                 let package = markdownPackageCache.package(for: message, theme: theme)
                 markdownViewForSizeCalculation.setMarkdownManually(package)
                 let boundingSize = markdownViewForSizeCalculation.boundingSize(for: containerWidth)
-                return ceil(boundingSize.height)
+                var height = ceil(boundingSize.height)
+                if let modelName = message.modelDisplayName, !modelName.isEmpty {
+                    let labelSize = boundingSize(
+                        with: containerWidth,
+                        for: .init(string: modelName, attributes: [
+                            .font: theme.fonts.footnote,
+                        ])
+                    )
+                    height += ceil(labelSize.height) + AiMessageView.metadataSpacing
+                }
+                return height
             case .hint:
                 return ceil(theme.fonts.footnote.lineHeight + 16)
             case .webSearchContent:
@@ -160,6 +170,7 @@ extension MessageListView: ListViewAdapter {
         } else if let aiMessageView = rowView as? AiMessageView {
             if case let .aiContent(_, message) = entry {
                 aiMessageView.theme = theme
+                aiMessageView.modelName = message.modelDisplayName
                 let package = markdownPackageCache.package(for: message, theme: theme)
                 aiMessageView.markdownView.setMarkdown(package)
                 aiMessageView.linkTapHandler = { [weak self] link, range, touchLocation in

--- a/FlowDown/Interface/Components/MessageListView/MessageListView+DataSource.swift
+++ b/FlowDown/Interface/Components/MessageListView/MessageListView+DataSource.swift
@@ -48,6 +48,8 @@ extension MessageListView {
         var isRevealed: Bool
         var isThinking: Bool
         var thinkingDuration: TimeInterval
+        var modelIdentifier: String?
+        var modelDisplayName: String?
 
         init(from message: Message) {
             id = message.objectId
@@ -57,6 +59,14 @@ extension MessageListView {
             isRevealed = true
             isThinking = false
             thinkingDuration = 0
+            modelIdentifier = message.modelIdentifier
+            if let identifier = modelIdentifier {
+                let displayName = ModelManager.shared.modelName(identifier: identifier)
+                let trimmedDisplayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+                modelDisplayName = trimmedDisplayName.isEmpty || trimmedDisplayName == "-" ? nil : trimmedDisplayName
+            } else {
+                modelDisplayName = nil
+            }
         }
     }
 

--- a/Frameworks/Storage/Sources/Storage/Tables/Message.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/Message.swift
@@ -92,6 +92,78 @@ public final class Message: Identifiable, Codable, TableNamed, DeviceOwned, Tabl
     }
 }
 
+public extension Message {
+    private struct MetadataPayload: Codable, Equatable {
+        var modelIdentifier: String?
+
+        var isEmpty: Bool {
+            if let modelIdentifier,
+               !modelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                return false
+            }
+            return true
+        }
+    }
+
+    private static let metadataDecoder: JSONDecoder = .init()
+    private static let metadataEncoder: JSONEncoder = .init()
+
+    private var currentMetadataPayload: MetadataPayload {
+        guard
+            let metadata,
+            !metadata.isEmpty,
+            let payload = try? Self.metadataDecoder.decode(MetadataPayload.self, from: metadata)
+        else {
+            return .init()
+        }
+        return payload
+    }
+
+    private func updateMetadataPayload(_ transform: (inout MetadataPayload) -> Void) {
+        var payload = currentMetadataPayload
+        let previous = payload
+        transform(&payload)
+
+        if payload == previous {
+            return
+        }
+
+        if payload.isEmpty {
+            if metadata != nil {
+                metadata = nil
+                markModified()
+            }
+            return
+        }
+
+        guard let data = try? Self.metadataEncoder.encode(payload) else {
+            return
+        }
+
+        metadata = data
+        markModified()
+    }
+
+    var modelIdentifier: String? {
+        get {
+            let identifier = currentMetadataPayload.modelIdentifier?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let identifier, !identifier.isEmpty else { return nil }
+            return identifier
+        }
+        set {
+            updateMetadataPayload { payload in
+                let trimmed = newValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+                payload.modelIdentifier = {
+                    guard let trimmed, !trimmed.isEmpty else { return nil }
+                    return trimmed
+                }()
+            }
+        }
+    }
+}
+
 extension Message: Updatable {
     @discardableResult
     public func update<Value: Equatable>(_ keyPath: ReferenceWritableKeyPath<Message, Value>, to newValue: Value) -> Bool {


### PR DESCRIPTION
Add model identifier display to assistant messages to show which model generated each response.

This PR implements the feature requested in issue #110. It captures the responding model identifier within each stored assistant message, tags all new assistant replies with the active model identifier, and surfaces the model name as a badge above assistant markdown content in the UI. This allows users to easily see which model contributed to each part of the conversation.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f803f70-d89f-4d92-ac7e-f2dcb0f7aa0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f803f70-d89f-4d92-ac7e-f2dcb0f7aa0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

