### PR TITLE
Implement flowdown issue 67

### DIFF
--- a/FlowDown/Backend/Conversation/Session/ConversationSession.swift
+++ b/FlowDown/Backend/Conversation/Session/ConversationSession.swift
@@ -317,11 +317,64 @@ final class ConversationSession: Identifiable {
         return nil
     }
 
+    func nextAttemptIndex(forParent parentUserMessageId: Message.ID) -> Int {
+        let attempts = messages.compactMap { message -> Int? in
+            guard message.role == .assistant,
+                  let metadata = message.replyMetadata,
+                  metadata.parentUserMessageId == parentUserMessageId
+            else {
+                return nil
+            }
+            return metadata.attemptIndex
+        }
+        let maxAttempt = attempts.max() ?? 0
+        return maxAttempt + 1
+    }
+
+    private func markAssistantMessageHistorical(
+        _ assistantMessage: Message,
+        parentUserMessage: Message
+    ) {
+        let parentId = parentUserMessage.objectId
+        let attemptIndex: Int
+        if let metadata = assistantMessage.replyMetadata {
+            attemptIndex = metadata.attemptIndex
+        } else {
+            let attempts = messages.compactMap { message -> Int? in
+                guard message.role == .assistant,
+                      let metadata = message.replyMetadata,
+                      metadata.parentUserMessageId == parentId
+                else {
+                    return nil
+                }
+                return metadata.attemptIndex
+            }
+            attemptIndex = max(attempts.max() ?? 0, 0) + 1
+        }
+
+        assistantMessage.replyMetadata = .init(
+            parentUserMessageId: parentId,
+            attemptIndex: attemptIndex,
+            isHistorical: true
+        )
+        sdb.messagePut(messages: [assistantMessage])
+        notifyMessagesDidChange(scrolling: false)
+    }
+
     func retry(byClearAfter messageIdentifier: Message.ID, currentMessageListView: MessageListView) {
+        guard let assistantMessage = message(for: messageIdentifier),
+              assistantMessage.role == .assistant
+        else {
+            assertionFailure()
+            return
+        }
+
         guard let nearestUserMessage = nearestUserMessage(beforeOrEqual: messageIdentifier) else {
             assertionFailure()
             return
         }
+
+        markAssistantMessageHistorical(assistantMessage, parentUserMessage: nearestUserMessage)
 
         let messageContent = nearestUserMessage.document
         let messageAttachments = attachments(for: nearestUserMessage.objectId)
@@ -329,8 +382,7 @@ final class ConversationSession: Identifiable {
         var editorObject = ConversationManager.shared.getRichEditorObject(identifier: id) ?? .init()
         editorObject.text = messageContent
 
-        editorObject.attachments = messageAttachments.compactMap {
-            attachment -> RichEditorView.Object.Attachment? in
+        editorObject.attachments = messageAttachments.compactMap { attachment -> RichEditorView.Object.Attachment? in
             guard let type = RichEditorView
                 .Object
                 .Attachment
@@ -353,12 +405,12 @@ final class ConversationSession: Identifiable {
             return
         }
 
-        deleteCurrentAndAfter(messageIdentifier: nearestUserMessage.objectId) {
-            self.doInfere(
-                modelID: modelID,
-                currentMessageListView: currentMessageListView,
-                inputObject: editorObject
-            ) {}
-        }
+        doInfere(
+            modelID: modelID,
+            currentMessageListView: currentMessageListView,
+            inputObject: editorObject,
+            contextLimitMessageID: nearestUserMessage.objectId,
+            reuseUserMessageID: nearestUserMessage.objectId
+        ) {}
     }
 }

--- a/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+BuildMessages.swift
+++ b/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+BuildMessages.swift
@@ -13,9 +13,13 @@ import Storage
 extension ConversationSession {
     func buildInitialRequestMessages(
         _ requestMessages: inout [ChatRequestBody.Message],
-        _ modelCapabilities: Set<ModelCapabilities>
+        _ modelCapabilities: Set<ModelCapabilities>,
+        limitToMessageId: Message.ID?
     ) {
         for message in messages {
+            if let limitToMessageId, message.objectId == limitToMessageId {
+                break
+            }
             switch message.role {
             case .system:
                 guard !message.document.isEmpty else { continue }
@@ -48,6 +52,9 @@ extension ConversationSession {
                     assertionFailure()
                 }
             case .assistant:
+                if message.isHistoricalReply {
+                    continue
+                }
                 guard !message.document.isEmpty else { continue }
                 requestMessages.append(.assistant(content: .text(message.document)))
             default:

--- a/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+Execute.swift
+++ b/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+Execute.swift
@@ -17,6 +17,8 @@ extension ConversationSession {
         modelID: ModelManager.ModelIdentifier,
         currentMessageListView: MessageListView,
         inputObject: RichEditorView.Object,
+        contextLimitMessageID: Message.ID? = nil,
+        reuseUserMessageID: Message.ID? = nil,
         completion: @escaping () -> Void
     ) {
         cancelCurrentTask { [self] in
@@ -56,7 +58,9 @@ extension ConversationSession {
                 await doInfereExecute(
                     modelID: modelID,
                     currentMessageListView: currentMessageListView,
-                    inputObject: inputObject
+                    inputObject: inputObject,
+                    contextLimitMessageID: contextLimitMessageID,
+                    reuseUserMessageID: reuseUserMessageID
                 )
                 self.currentTask = nil
                 // Check if there's a pending refresh after task completion
@@ -83,7 +87,9 @@ extension ConversationSession {
     private nonisolated func doInfereExecute(
         modelID: ModelManager.ModelIdentifier,
         currentMessageListView: MessageListView,
-        inputObject: RichEditorView.Object
+        inputObject: RichEditorView.Object,
+        contextLimitMessageID: Message.ID?,
+        reuseUserMessageID: Message.ID?
     ) async {
         var object = inputObject
 
@@ -111,7 +117,11 @@ extension ConversationSession {
         // MARK: - 上下文转译到请求体 不包含当前编辑框中的附件
 
         var requestMessages: [ChatRequestBody.Message] = []
-        buildInitialRequestMessages(&requestMessages, modelCapabilities)
+        buildInitialRequestMessages(
+            &requestMessages,
+            modelCapabilities,
+            limitToMessageId: contextLimitMessageID
+        )
 
         do {
             try await doInfereExecuteCore(
@@ -123,7 +133,8 @@ extension ConversationSession {
                 modelWillExecuteTools,
                 modelWillGoSearchWeb,
                 modelContextLength,
-                modelID
+                modelID,
+                reuseUserMessageID
             )
             saveIfNeeded(object)
         } catch {
@@ -172,7 +183,8 @@ extension ConversationSession {
         _ modelWillExecuteTools: Bool,
         _ modelWillGoSearchWeb: Bool,
         _ modelContextLength: Int,
-        _ modelID: ModelManager.ModelIdentifier
+        _ modelID: ModelManager.ModelIdentifier,
+        _ reuseUserMessageID: Message.ID?
     ) async throws {
         try checkCancellation()
         await currentMessageListView.loading()
@@ -180,10 +192,21 @@ extension ConversationSession {
         // MARK: - 添加用户的消息到储存框架
 
         let document = object.text
-        let userMessage = appendNewMessage(role: .user)
-        userMessage.update(\.document, to: document)
 
-        addAttachments(object.attachments, to: userMessage)
+        let userMessage: Message
+        if let reuseUserMessageID,
+           let existingUserMessage = message(for: reuseUserMessageID),
+           existingUserMessage.role == .user
+        {
+            userMessage = existingUserMessage
+            object.text = existingUserMessage.document
+        } else {
+            let newUserMessage = appendNewMessage(role: .user)
+            newUserMessage.update(\.document, to: document)
+            addAttachments(object.attachments, to: newUserMessage)
+            userMessage = newUserMessage
+        }
+
         await requestUpdate(view: currentMessageListView)
 
         // MARK: - 添加 Attachment 数据到持久化内容
@@ -277,6 +300,7 @@ extension ConversationSession {
                 &requestMessages,
                 toolsDefinitions,
                 modelWillExecuteTools,
+                parentUserMessageId: userMessage.objectId,
                 linkedContents: linkedContents,
                 requestLinkContentIndex: requestLinkContentIndex
             )

--- a/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+ExecuteOnce.swift
+++ b/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+ExecuteOnce.swift
@@ -17,13 +17,22 @@ extension ConversationSession {
         _ requestMessages: inout [ChatRequestBody.Message],
         _ tools: [ChatRequestBody.Tool]?,
         _ modelWillExecuteTools: Bool,
+        parentUserMessageId: Message.ID?,
         linkedContents: [Int: URL],
         requestLinkContentIndex: @escaping (URL) -> Int
     ) async throws -> Bool {
         await requestUpdate(view: currentMessageListView)
         await currentMessageListView.loading()
 
+        let attemptIndex = parentUserMessageId.map { nextAttemptIndex(forParent: $0) }
         let message = appendNewMessage(role: .assistant)
+        if let parentUserMessageId, let attemptIndex {
+            message.replyMetadata = .init(
+                parentUserMessageId: parentUserMessageId,
+                attemptIndex: attemptIndex,
+                isHistorical: false
+            )
+        }
 
         let stream = try await ModelManager.shared.streamingInfer(
             with: modelID,

--- a/FlowDown/Backend/Conversation/Session/Message+ReplyMetadata.swift
+++ b/FlowDown/Backend/Conversation/Session/Message+ReplyMetadata.swift
@@ -1,0 +1,69 @@
+//
+//  Message+ReplyMetadata.swift
+//  FlowDown
+//
+//  Created by GPT-5 Codex on 2025/11/05.
+//
+
+import Foundation
+import Storage
+
+extension Message {
+    struct MetadataContainer: Codable, Equatable {
+        var reply: ReplyMetadata?
+
+        init(reply: ReplyMetadata? = nil) {
+            self.reply = reply
+        }
+    }
+
+    struct ReplyMetadata: Codable, Equatable {
+        public var parentUserMessageId: Message.ID
+        public var attemptIndex: Int
+        public var isHistorical: Bool
+
+        public init(parentUserMessageId: Message.ID, attemptIndex: Int, isHistorical: Bool) {
+            self.parentUserMessageId = parentUserMessageId
+            self.attemptIndex = attemptIndex
+            self.isHistorical = isHistorical
+        }
+    }
+
+    private static let metadataDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        return decoder
+    }()
+
+    private static let metadataEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    var replyMetadata: ReplyMetadata? {
+        get { metadataContainer.reply }
+        set {
+            var container = metadataContainer
+            container.reply = newValue
+            updateMetadataContainer(container)
+        }
+    }
+
+    var isHistoricalReply: Bool {
+        replyMetadata?.isHistorical ?? false
+    }
+
+    private var metadataContainer: MetadataContainer {
+        if let metadata,
+           let container = try? Self.metadataDecoder.decode(MetadataContainer.self, from: metadata)
+        {
+            return container
+        }
+        return .init()
+    }
+
+    private func updateMetadataContainer(_ container: MetadataContainer) {
+        let data = try? Self.metadataEncoder.encode(container)
+        update(\.metadata, to: data)
+    }
+}

--- a/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+WebSearch.swift
+++ b/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+WebSearch.swift
@@ -457,8 +457,16 @@ extension ConversationSession {
 
         // 获取更完整的上下文信息，包括角色和时间戳
         let prevMsgs = messages
-            .filter { [.user, .assistant].contains($0.role) }
-            .filter { !$0.document.isEmpty }
+            .filter { message in
+                switch message.role {
+                case .user:
+                    return !message.document.isEmpty
+                case .assistant:
+                    return !message.isHistoricalReply && !message.document.isEmpty
+                default:
+                    return false
+                }
+            }
             .suffix(5) // 限制最近 n 条消息避免上下文过长
             .map { message in
                 let rolePrefix = message.role == .user ? "[User]" : "[Assistant]"


### PR DESCRIPTION
Implement a retry mechanism for assistant messages to allow users to retry assistant responses, preserving previous attempts and ensuring the model continues from the latest reply, addressing issue #67.

---
<a href="https://cursor.com/background-agent?bcId=bc-74edb812-c734-492d-aac4-5388db7c6d41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74edb812-c734-492d-aac4-5388db7c6d41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

