### PR TITLE
Implement FlowDown issue 110

### DIFF
--- a/FlowDown/Backend/Conversation/ConversationManager+CRUD.swift
+++ b/FlowDown/Backend/Conversation/ConversationManager+CRUD.swift
@@ -73,7 +73,7 @@ extension ConversationManager {
                     """
                 )
 
-                session.appendNewMessage(role: .assistant) {
+                session.appendNewMessage(role: .assistant, modelIdentifier: "") {
                     $0.update(\.document, to: guide)
                 }
                 session.save()

--- a/FlowDown/Backend/Conversation/ConversationManager+Compress.swift
+++ b/FlowDown/Backend/Conversation/ConversationManager+Compress.swift
@@ -56,6 +56,7 @@ extension ConversationManager {
             $0.update(\.shouldAutoRename, to: true)
         }
         let sess = ConversationSessionManager.shared.session(for: conv.id)
+        sess.models.chat = model
 
         sess.appendNewMessage(role: .hint) {
             $0.update(\.document, to: String(localized: "This conversation is created by compressing \"\(title)\"."))
@@ -97,7 +98,7 @@ extension ConversationManager {
                     with: model,
                     input: messageBody
                 )
-                let mess = sess.appendNewMessage(role: .assistant)
+                let mess = sess.appendNewMessage(role: .assistant, modelIdentifier: model)
                 for try await resp in stream where !resp.content.isEmpty {
                     mess.update(\.document, to: resp.content)
                     sess.notifyMessagesDidChange()
@@ -108,7 +109,7 @@ extension ConversationManager {
                 await MainActor.run { completion(.success(conv.id)) }
             } catch {
                 await MainActor.run {
-                    sess.appendNewMessage(role: .assistant) {
+                    sess.appendNewMessage(role: .assistant, modelIdentifier: model) {
                         $0.update(
                             \.document,
                             to: String(localized: "An error occurred during compression: \(error.localizedDescription)")

--- a/FlowDown/Backend/Conversation/Session/ConversationSession.swift
+++ b/FlowDown/Backend/Conversation/Session/ConversationSession.swift
@@ -93,13 +93,30 @@ final class ConversationSession: Identifiable {
 
     /// Appends a new message to the conversation.
     @discardableResult
-    func appendNewMessage(role: Message.Role, _ block: Storage.MessageMakeInitDataBlock? = nil) -> Message {
+    func appendNewMessage(
+        role: Message.Role,
+        modelIdentifier explicitModelIdentifier: ModelManager.ModelIdentifier? = nil,
+        _ block: Storage.MessageMakeInitDataBlock? = nil
+    ) -> Message {
+        let resolvedModelIdentifier: ModelManager.ModelIdentifier? = {
+            if let explicitModelIdentifier, !explicitModelIdentifier.isEmpty {
+                return explicitModelIdentifier
+            }
+            if role == .assistant {
+                return models.chat
+            }
+            return nil
+        }()
+
         let message = sdb.makeMessage(with: id) {
             if let block {
                 block($0)
             }
 
             $0.update(\.role, to: role)
+            if let resolvedModelIdentifier, !resolvedModelIdentifier.isEmpty {
+                $0.update(\.modelIdentifier, to: resolvedModelIdentifier)
+            }
         }
 
         messages.append(message)

--- a/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+Execute.swift
+++ b/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+Execute.swift
@@ -128,7 +128,7 @@ extension ConversationSession {
             saveIfNeeded(object)
         } catch {
             logger.error("\(error.localizedDescription)")
-            let errorMessage = appendNewMessage(role: .assistant)
+            let errorMessage = appendNewMessage(role: .assistant, modelIdentifier: modelID)
             errorMessage.update(\.document, to: "*\(error.localizedDescription)*")
             await requestUpdate(view: currentMessageListView)
             await requestUpdate(view: currentMessageListView)

--- a/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+ExecuteOnce.swift
+++ b/FlowDown/Backend/Conversation/Session/Execute/ConversationSession+ExecuteOnce.swift
@@ -23,7 +23,7 @@ extension ConversationSession {
         await requestUpdate(view: currentMessageListView)
         await currentMessageListView.loading()
 
-        let message = appendNewMessage(role: .assistant)
+        let message = appendNewMessage(role: .assistant, modelIdentifier: modelID)
 
         let stream = try await ModelManager.shared.streamingInfer(
             with: modelID,

--- a/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+Images.swift
+++ b/FlowDown/Backend/Conversation/Session/PreAction/ConversationSession+Images.swift
@@ -74,7 +74,7 @@ extension ConversationSession {
         try await Task.sleep(for: .seconds(0.5)) // for animation
 
         var llmText = ""
-        let message = appendNewMessage(role: .assistant)
+        let message = appendNewMessage(role: .assistant, modelIdentifier: decision)
         for try await resp in try await ModelManager.shared.streamingInfer(
             with: decision,
             input: messages

--- a/FlowDown/Interface/Components/MessageListView/Components/AiMessageView.swift
+++ b/FlowDown/Interface/Components/MessageListView/Components/AiMessageView.swift
@@ -7,9 +7,45 @@ import ListViewKit
 import MarkdownView
 import UIKit
 
+private enum AiMessageViewLayout {
+    static let badgeSpacing: CGFloat = 8
+    static let badgeCornerRadius: CGFloat = 10
+}
+
+private final class CapsuleLabel: UILabel {
+    var contentInset: UIEdgeInsets = .init(top: 4, left: 10, bottom: 4, right: 10)
+
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return .init(width: size.width + contentInset.left + contentInset.right, height: size.height + contentInset.top + contentInset.bottom)
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let target = CGSize(
+            width: max(0, size.width - contentInset.left - contentInset.right),
+            height: max(0, size.height - contentInset.top - contentInset.bottom)
+        )
+        let base = super.sizeThatFits(target)
+        return .init(width: base.width + contentInset.left + contentInset.right, height: base.height + contentInset.top + contentInset.bottom)
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: contentInset))
+    }
+}
+
 final class AiMessageView: MessageListRowView {
     private(set) lazy var markdownView: MarkdownTextView = .init().with {
         $0.throttleInterval = 1 / 60
+    }
+
+    private let modelBadgeLabel: CapsuleLabel = .init()
+
+    var modelName: String? {
+        didSet {
+            guard oldValue != modelName else { return }
+            updateModelBadge()
+        }
     }
 
     var linkTapHandler: ((LinkPayload, NSRange, CGPoint) -> Void)? {
@@ -33,16 +69,66 @@ final class AiMessageView: MessageListRowView {
     }
 
     private func configureSubviews() {
+        modelBadgeLabel.isHidden = true
+        modelBadgeLabel.numberOfLines = 1
+        modelBadgeLabel.textAlignment = .left
+        modelBadgeLabel.layer.cornerRadius = AiMessageViewLayout.badgeCornerRadius
+        modelBadgeLabel.layer.cornerCurve = .continuous
+        modelBadgeLabel.layer.masksToBounds = true
+
+        contentView.addSubview(modelBadgeLabel)
         contentView.addSubview(markdownView)
+    }
+
+    override func themeDidUpdate() {
+        super.themeDidUpdate()
+        modelBadgeLabel.font = theme.fonts.footnote
+        modelBadgeLabel.textColor = .secondaryLabel
+        modelBadgeLabel.backgroundColor = .tertiarySystemBackground
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        modelName = nil
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        markdownView.frame = contentView.bounds
+
+        var nextOriginY: CGFloat = 0
+        if let text = modelBadgeLabel.text, !text.isEmpty, !modelBadgeLabel.isHidden {
+            let size = modelBadgeLabel.sizeThatFits(CGSize(width: contentView.bounds.width, height: .greatestFiniteMagnitude))
+            let width = min(size.width, contentView.bounds.width)
+            modelBadgeLabel.frame = .init(origin: .zero, size: .init(width: width, height: size.height))
+            nextOriginY = modelBadgeLabel.frame.maxY + AiMessageViewLayout.badgeSpacing
+        } else {
+            modelBadgeLabel.frame = .zero
+        }
+
+        let availableHeight = max(0, contentView.bounds.height - nextOriginY)
+        markdownView.frame = .init(x: 0, y: nextOriginY, width: contentView.bounds.width, height: availableHeight)
         markdownView.bindContentOffset(from: nearestScrollView)
+    }
+
+    private func updateModelBadge() {
+        if let name = modelName, !name.isEmpty {
+            modelBadgeLabel.text = name
+            modelBadgeLabel.isHidden = false
+        } else {
+            modelBadgeLabel.isHidden = true
+            modelBadgeLabel.text = nil
+        }
+        setNeedsLayout()
+    }
+}
+
+extension AiMessageView {
+    static func badgeHeight(for modelName: String?, theme: MarkdownTheme, availableWidth: CGFloat) -> CGFloat {
+        guard let modelName, !modelName.isEmpty, availableWidth > 0 else { return 0 }
+        let label = CapsuleLabel()
+        label.font = theme.fonts.footnote
+        label.text = modelName
+        let size = label.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude))
+        return size.height + AiMessageViewLayout.badgeSpacing
     }
 }

--- a/FlowDown/Interface/Components/MessageListView/MessageListView+Adapter.swift
+++ b/FlowDown/Interface/Components/MessageListView/MessageListView+Adapter.swift
@@ -113,7 +113,11 @@ extension MessageListView: ListViewAdapter {
                 let package = markdownPackageCache.package(for: message, theme: theme)
                 markdownViewForSizeCalculation.setMarkdownManually(package)
                 let boundingSize = markdownViewForSizeCalculation.boundingSize(for: containerWidth)
-                return ceil(boundingSize.height)
+                var height = ceil(boundingSize.height)
+                if let displayName = message.modelDisplayName {
+                    height += AiMessageView.badgeHeight(for: displayName, theme: theme, availableWidth: containerWidth)
+                }
+                return height
             case .hint:
                 return ceil(theme.fonts.footnote.lineHeight + 16)
             case .webSearchContent:
@@ -160,6 +164,7 @@ extension MessageListView: ListViewAdapter {
         } else if let aiMessageView = rowView as? AiMessageView {
             if case let .aiContent(_, message) = entry {
                 aiMessageView.theme = theme
+                aiMessageView.modelName = message.modelDisplayName
                 let package = markdownPackageCache.package(for: message, theme: theme)
                 aiMessageView.markdownView.setMarkdown(package)
                 aiMessageView.linkTapHandler = { [weak self] link, range, touchLocation in

--- a/FlowDown/Interface/Components/MessageListView/MessageListView+DataSource.swift
+++ b/FlowDown/Interface/Components/MessageListView/MessageListView+DataSource.swift
@@ -48,6 +48,7 @@ extension MessageListView {
         var isRevealed: Bool
         var isThinking: Bool
         var thinkingDuration: TimeInterval
+        var modelIdentifier: String
 
         init(from message: Message) {
             id = message.objectId
@@ -57,6 +58,7 @@ extension MessageListView {
             isRevealed = true
             isThinking = false
             thinkingDuration = 0
+            modelIdentifier = message.modelIdentifier
         }
     }
 
@@ -68,6 +70,15 @@ extension MessageListView {
             items.reduce(into: .init()) { result, item in
                 result += item.id.uuidString
             }
+        }
+    }
+
+    extension MessageRepresentation {
+        var modelDisplayName: String? {
+            let identifier = modelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !identifier.isEmpty else { return nil }
+            let displayName = ModelManager.shared.modelName(identifier: identifier)
+            return displayName == "-" ? nil : displayName
         }
     }
 

--- a/Frameworks/Storage/Sources/Storage/Storage/DBMigration.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/DBMigration.swift
@@ -507,3 +507,22 @@ struct MigrationV3ToV4: DBMigration {
         Logger.database.info("[*] migrate version \(fromVersion.rawValue) -> \(toVersion.rawValue) end elapsed \(Int(elapsed), privacy: .public)ms")
     }
 }
+
+struct MigrationV4ToV5: DBMigration {
+    let fromVersion: DBVersion = .Version4
+    let toVersion: DBVersion = .Version5
+    let requiresDataMigration: Bool = false
+
+    func migrate(db: Database) throws {
+        let start = Date.now
+        Logger.database.info("[*] migrate version \(fromVersion.rawValue) -> \(toVersion.rawValue) begin")
+
+        // Add modelIdentifier column to Message table
+        try db.create(table: Message.tableName, of: Message.self)
+
+        try db.exec(StatementPragma().pragma(.userVersion).to(toVersion.rawValue))
+
+        let elapsed = Date.now.timeIntervalSince(start) * 1000.0
+        Logger.database.info("[*] migrate version \(fromVersion.rawValue) -> \(toVersion.rawValue) end elapsed \(Int(elapsed), privacy: .public)ms")
+    }
+}

--- a/Frameworks/Storage/Sources/Storage/Storage/DBVersion.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/DBVersion.swift
@@ -11,4 +11,5 @@ enum DBVersion: Int, CaseIterable {
     case Version2 = 2
     case Version3 = 3
     case Version4 = 4
+    case Version5 = 5
 }

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage.swift
@@ -82,6 +82,7 @@ public class Storage {
                 MigrationV1ToV2(deviceId: Storage.deviceId, requiresDataMigration: true),
                 MigrationV2ToV3(),
                 MigrationV3ToV4(),
+                MigrationV4ToV5(),
             ]
         } else {
             initVersion = .Version1
@@ -89,6 +90,7 @@ public class Storage {
                 MigrationV1ToV2(deviceId: Storage.deviceId, requiresDataMigration: false),
                 MigrationV2ToV3(),
                 MigrationV3ToV4(),
+                MigrationV4ToV5(),
             ]
         }
 

--- a/Frameworks/Storage/Sources/Storage/Tables/Message.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/Message.swift
@@ -32,6 +32,7 @@ public final class Message: Identifiable, Codable, TableNamed, DeviceOwned, Tabl
     public package(set) var documentNodes: [MarkdownBlockNode] = []
     public package(set) var webSearchStatus: WebSearchStatus = .init()
     public package(set) var toolStatus: ToolStatus = .init()
+    public package(set) var modelIdentifier: String = ""
 
     public package(set) var removed: Bool = false
     public package(set) var modified: Date = .now
@@ -58,6 +59,7 @@ public final class Message: Identifiable, Codable, TableNamed, DeviceOwned, Tabl
             BindColumnConstraint(documentNodes, isNotNull: true, defaultTo: [MarkdownBlockNode]())
             BindColumnConstraint(webSearchStatus, isNotNull: true, defaultTo: WebSearchStatus())
             BindColumnConstraint(toolStatus, isNotNull: true, defaultTo: ToolStatus())
+            BindColumnConstraint(modelIdentifier, isNotNull: true, defaultTo: "")
             BindColumnConstraint(metadata, isNotNull: false)
 
             BindIndex(creation, namedWith: "_creationIndex")
@@ -77,6 +79,7 @@ public final class Message: Identifiable, Codable, TableNamed, DeviceOwned, Tabl
         case documentNodes
         case webSearchStatus
         case toolStatus
+        case modelIdentifier
 
         case removed
         case modified
@@ -264,6 +267,7 @@ extension Message: Equatable {
             lhs.isThinkingFold == rhs.isThinkingFold &&
             lhs.document == rhs.document &&
             lhs.webSearchStatus == rhs.webSearchStatus &&
+            lhs.modelIdentifier == rhs.modelIdentifier &&
             lhs.removed == rhs.removed &&
             lhs.modified == rhs.modified
     }
@@ -281,7 +285,7 @@ extension Message: Hashable {
         hasher.combine(isThinkingFold)
         hasher.combine(document)
         hasher.combine(webSearchStatus)
-
+        hasher.combine(modelIdentifier)
         hasher.combine(removed)
         hasher.combine(modified)
     }


### PR DESCRIPTION
Add per-message `modelIdentifier` storage with a v5 schema migration and display the model name as a badge above assistant messages.

This implements the feature requested in #110, allowing users to see which model generated each assistant response.

---
<a href="https://cursor.com/background-agent?bcId=bc-9de476a9-e398-4f5f-b2c6-6d746284b860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9de476a9-e398-4f5f-b2c6-6d746284b860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

