### PR TITLE
Check list behavior when keyboard appears

### DIFF
--- a/FlowDown/Interface/Components/MessageListView/MessageListView.swift
+++ b/FlowDown/Interface/Components/MessageListView/MessageListView.swift
@@ -118,9 +118,7 @@ final class MessageListView: UIView {
         if isAutoScrollingToBottom || wasNearBottom {
             let targetOffset = listView.maximumContentOffset
             if abs(listView.contentOffset.y - targetOffset.y) > autoScrollTolerance {
-                UIView.performWithoutAnimation {
-                    listView.setContentOffset(targetOffset, animated: false)
-                }
+                listView.scroll(to: targetOffset)
             }
             if wasNearBottom {
                 isAutoScrollingToBottom = true


### PR DESCRIPTION
Keeps `MessageListView` scrolled to the bottom when the keyboard appears, maintaining the user's view of the latest messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-52440fcb-5f5d-41f3-97d8-d5c3ae6af67f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-52440fcb-5f5d-41f3-97d8-d5c3ae6af67f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

