### PR TITLE
Add button to create and open new memory

### DIFF
--- a/FlowDown/Backend/ModelTools/MemoryTools/MemoryStore.swift
+++ b/FlowDown/Backend/ModelTools/MemoryTools/MemoryStore.swift
@@ -36,7 +36,7 @@ public class MemoryStore: ObservableObject {
 
     // MARK: - Public Async API
 
-    func storeAsync(content: String, conversationId: String? = nil) async throws {
+    func storeAsync(content: String, conversationId: String? = nil) async throws -> Memory {
         let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedContent.isEmpty else {
             throw MemoryStoreError.invalidContent("Memory content cannot be empty")
@@ -48,7 +48,7 @@ public class MemoryStore: ObservableObject {
 
         let contextId = conversationId ?? getCurrentConversationId()
 
-        try await withCheckedThrowingContinuation { continuation in
+        return try await withCheckedThrowingContinuation { continuation in
             queue.async {
                 do {
                     let storage = try Storage.db()
@@ -61,7 +61,7 @@ public class MemoryStore: ObservableObject {
                         await self.updateMemoryCount()
                     }
 
-                    continuation.resume()
+                    continuation.resume(returning: memory)
                 } catch {
                     continuation.resume(throwing: MemoryStoreError.storageError(error.localizedDescription))
                 }


### PR DESCRIPTION
Adds a "Create Memory" button to the Memory List page to allow users to quickly create and edit new memories.

The `MemoryStore.storeAsync` method was modified to return the newly created `Memory` object, enabling the UI to immediately navigate to the editor for the new entry. An error alert was also added to handle potential memory creation failures gracefully.

---
<a href="https://cursor.com/background-agent?bcId=bc-b580dd1b-8ca9-49d6-a1fa-97ee4fc97f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b580dd1b-8ca9-49d6-a1fa-97ee4fc97f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

