### PR TITLE
Add memory creation and edit button

### DIFF
--- a/FlowDown/Backend/ModelTools/MemoryTools/MemoryStore.swift
+++ b/FlowDown/Backend/ModelTools/MemoryTools/MemoryStore.swift
@@ -36,7 +36,7 @@ public class MemoryStore: ObservableObject {
 
     // MARK: - Public Async API
 
-    func storeAsync(content: String, conversationId: String? = nil) async throws {
+    func storeMemoryAsync(content: String, conversationId: String? = nil) async throws -> Memory {
         let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedContent.isEmpty else {
             throw MemoryStoreError.invalidContent("Memory content cannot be empty")
@@ -48,7 +48,7 @@ public class MemoryStore: ObservableObject {
 
         let contextId = conversationId ?? getCurrentConversationId()
 
-        try await withCheckedThrowingContinuation { continuation in
+        return try await withCheckedThrowingContinuation { continuation in
             queue.async {
                 do {
                     let storage = try Storage.db()
@@ -61,7 +61,9 @@ public class MemoryStore: ObservableObject {
                         await self.updateMemoryCount()
                     }
 
-                    continuation.resume()
+                    continuation.resume(returning: memory)
+                } catch let error as Storage.MemoryError {
+                    continuation.resume(throwing: MemoryStoreError.storageError(error.localizedDescription))
                 } catch {
                     continuation.resume(throwing: MemoryStoreError.storageError(error.localizedDescription))
                 }

--- a/FlowDown/Interface/ViewController/SettingController/Memory/MemoryListController.swift
+++ b/FlowDown/Interface/ViewController/SettingController/Memory/MemoryListController.swift
@@ -15,6 +15,7 @@ class MemoryListController: UIViewController {
     private let searchController = UISearchController(searchResultsController: nil)
     private var memories: [Memory] = []
     private var filteredMemories: [Memory] = []
+    private static let newMemoryPlaceholder = String(localized: "Memory")
 
     private var isSearching: Bool {
         let text = searchController.searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -46,6 +47,12 @@ class MemoryListController: UIViewController {
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
         navigationItem.preferredSearchBarPlacement = .stacked
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            systemItem: .add,
+            target: self,
+            action: #selector(addMemoryTapped)
+        )
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "memory-list.add-memory"
 
         tableView.delegate = self
         tableView.dataSource = self
@@ -103,6 +110,35 @@ class MemoryListController: UIViewController {
 
     private func currentMemories() -> [Memory] {
         isSearching ? filteredMemories : memories
+    }
+
+    @objc
+    private func addMemoryTapped() {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let newMemory = try await MemoryStore.shared.storeMemoryAsync(content: Self.newMemoryPlaceholder)
+                let refreshed = try await MemoryStore.shared.getAllMemoriesAsync()
+                await MainActor.run {
+                    guard let self else { return }
+                    self.updateDataSource(with: refreshed)
+                    self.presentEditor(for: newMemory, isNew: true)
+                }
+            } catch {
+                await MainActor.run {
+                    guard let self else { return }
+                    let errorAlert = AlertViewController(
+                        title: "Error",
+                        message: "Failed to create memory: \(error.localizedDescription)"
+                    ) { context in
+                        context.addAction(title: "OK", attribute: .accent) {
+                            context.dispose()
+                        }
+                    }
+                    self.present(errorAlert, animated: true)
+                }
+            }
+        }
     }
 
     private func deleteMemory(at indexPath: IndexPath) {
@@ -327,10 +363,10 @@ class MemoryCell: UITableViewCell {
 }
 
 private extension MemoryListController {
-    func presentEditor(for memory: Memory) {
+    func presentEditor(for memory: Memory, isNew: Bool = false) {
         let controller = TextEditorContentController()
         controller.title = String(localized: "Memory")
-        controller.text = memory.content
+        controller.text = isNew ? "" : memory.content
         controller.callback = { [weak self] text in
             guard let self else { return }
             Task {
@@ -338,16 +374,12 @@ private extension MemoryListController {
                     try await MemoryStore.shared.updateMemoryAsync(id: memory.id, newContent: text)
                     let refreshed = try await MemoryStore.shared.getAllMemoriesAsync()
                     await MainActor.run {
-                        self.memories = refreshed
-                        if self.isSearching {
-                            self.searchMemories(query: self.searchController.searchBar.text ?? "")
-                        } else {
-                            self.filteredMemories = refreshed
-                            self.tableView.reloadData()
-                        }
+                        guard let self else { return }
+                        self.updateDataSource(with: refreshed)
                     }
                 } catch {
                     await MainActor.run {
+                        guard let self else { return }
                         let errorAlert = AlertViewController(
                             title: "Error",
                             message: "Failed to update memory: \(error.localizedDescription)"
@@ -361,6 +393,38 @@ private extension MemoryListController {
                 }
             }
         }
+
+        if isNew {
+            controller.cancelCallback = { [weak self] in
+                guard let self else { return }
+                Task {
+                    do {
+                        try await MemoryStore.shared.deleteMemoryAsync(id: memory.id)
+                        let refreshed = try await MemoryStore.shared.getAllMemoriesAsync()
+                        await MainActor.run {
+                            guard let self else { return }
+                            self.updateDataSource(with: refreshed)
+                        }
+                    } catch {
+                        await MainActor.run {
+                            guard let self else { return }
+                            let errorAlert = AlertViewController(
+                                title: "Error",
+                                message: "Failed to delete memory: \(error.localizedDescription)"
+                            ) { context in
+                                context.addAction(title: "OK", attribute: .accent) {
+                                    context.dispose()
+                                }
+                            }
+                            self.present(errorAlert, animated: true)
+                        }
+                    }
+                }
+            }
+        } else {
+            controller.cancelCallback = nil
+        }
+
         navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -368,5 +432,16 @@ private extension MemoryListController {
         let displayed = currentMemories()
         guard let row = displayed.firstIndex(where: { $0.id == memory.id }) else { return nil }
         return IndexPath(row: row, section: 0)
+    }
+
+    @MainActor
+    func updateDataSource(with refreshed: [Memory]) {
+        memories = refreshed
+        if isSearching {
+            searchMemories(query: searchController.searchBar.text ?? "")
+        } else {
+            filteredMemories = refreshed
+            tableView.reloadData()
+        }
     }
 }

--- a/FlowDown/Interface/ViewController/Supplement/TextEditorContentController.swift
+++ b/FlowDown/Interface/ViewController/Supplement/TextEditorContentController.swift
@@ -10,6 +10,7 @@ import UIKit
 class TextEditorContentController: UIViewController {
     var text: String = ""
     var callback: ((String) -> Void) = { _ in }
+    var cancelCallback: (() -> Void)?
 
     let textView = UITextView()
     var bottomOffset: CGFloat = 0
@@ -87,6 +88,7 @@ class TextEditorContentController: UIViewController {
 
     open func cancelDone() {
         textView.text = text // just in case
+        cancelCallback?()
         navigationController?.popViewController(animated: true)
     }
 }


### PR DESCRIPTION
Add an "Add" button to the memory list page to create new memories and immediately open them for editing, with automatic draft cleanup on cancellation.

---
<a href="https://cursor.com/background-agent?bcId=bc-56cb9246-c6f5-4ba4-a5d8-f795f19a30de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56cb9246-c6f5-4ba4-a5d8-f795f19a30de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

