### PR TITLE
Investigate and fix database and storage sync issues

### DIFF
--- a/Frameworks/Storage/Sources/Storage/Storage/Storage+UploadQueue.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage+UploadQueue.swift
@@ -500,6 +500,36 @@ package extension Storage {
         return objects
     }
 
+    /// 检查指定上传队列记录是否仍然存在。
+    /// - Parameters:
+    ///   - queueId: 队列主键
+    ///   - tableName: 同步表名
+    ///   - objectId: 对象ID
+    ///   - handle: 数据库句柄
+    /// - Returns: 若存在返回 true
+    func pendingUploadExists(queueId: UploadQueue.ID, tableName: String, objectId: String, handle: Handle? = nil) -> Bool {
+        let condition: Condition =
+            UploadQueue.Properties.id == queueId
+                && UploadQueue.Properties.tableName == tableName
+                && UploadQueue.Properties.objectId == objectId
+
+        let value: Value? = if let handle {
+            try? handle.getValue(
+                on: UploadQueue.Properties.id.count(),
+                fromTable: UploadQueue.tableName,
+                where: condition
+            )
+        } else {
+            try? db.getValue(
+                on: UploadQueue.Properties.id.count(),
+                fromTable: UploadQueue.tableName,
+                where: condition
+            )
+        }
+
+        return (value?.int64Value ?? 0) > 0
+    }
+
     /// 查询上传队列关联的真实数据对象
     /// - Parameters:
     ///   - objects: 上传队列

--- a/Frameworks/Storage/Sources/Storage/Storage/Storage.swift
+++ b/Frameworks/Storage/Sources/Storage/Storage/Storage.swift
@@ -112,6 +112,7 @@ public class Storage {
         try setup(db: db)
 
         try resetUploadQueueMaxID()
+        try normalizeUploadQueueDeviceId()
 
         // 将上传中/上传失败的同步记录重置为Pending
         try db.run(transaction: { [unowned self] in
@@ -195,6 +196,19 @@ public class Storage {
             .where(nameColumn == UploadQueue.tableName)
 
         try db.exec(updateTableSequence)
+    }
+
+    /// 确保上传队列上的记录归属于当前设备。
+    /// 较旧版本会使用对象来源的 deviceId，从而导致 CloudKit 回调后无法匹配本地队列。
+    private func normalizeUploadQueueDeviceId() throws {
+        let localDeviceId = Storage.deviceId
+        let update = StatementUpdate()
+            .update(table: UploadQueue.tableName)
+            .set(UploadQueue.Properties.deviceId)
+            .to(localDeviceId)
+            .where(UploadQueue.Properties.deviceId != localDeviceId)
+
+        try db.exec(update)
     }
 }
 

--- a/Frameworks/Storage/Sources/Storage/Sync/SyncEngine.swift
+++ b/Frameworks/Storage/Sources/Storage/Sync/SyncEngine.swift
@@ -828,26 +828,36 @@ private extension SyncEngine {
     ) async {
         var newPendingDatabaseChanges = [CKSyncEngine.PendingDatabaseChange]()
         var removePendingRecordZoneChanges = [CKSyncEngine.PendingRecordZoneChange]()
-        let deviceId = Storage.deviceId
         // 发送成功的，需要更新本地UploadQueue 状态
         if !savedRecords.isEmpty {
-            var savedLocalQueueIds: [(queueId: UploadQueue.ID, objectId: String, tableName: String)] = []
+            var queueCandidates: [(queueId: UploadQueue.ID, objectId: String, tableName: String)] = []
             var metadatas: [SyncMetadata] = []
             for savedRecord in savedRecords {
-                guard let (_, tableName) = UploadQueue.parseCKRecordID(savedRecord.recordID.recordName) else { continue }
-                guard let value = savedRecord.sentQueueId, let (localQueueId, objectId, sentDeviceId) = SyncEngine.parseCKRecordSentQueueId(value) else { continue }
-                if sentDeviceId == deviceId {
-                    savedLocalQueueIds.append((localQueueId, objectId, tableName))
-                    metadatas.append(SyncMetadata(record: savedRecord))
-                    // 清理临时文件
-                    savedRecord.clearTemporaryAssets(prefix: SyncEngine.temporaryAssetStorage)
-                }
+                guard let (objectId, tableName) = UploadQueue.parseCKRecordID(savedRecord.recordID.recordName) else { continue }
+                guard let value = savedRecord.sentQueueId, let (localQueueId, _, _) = SyncEngine.parseCKRecordSentQueueId(value) else { continue }
+
+                queueCandidates.append((localQueueId, objectId, tableName))
+                metadatas.append(SyncMetadata(record: savedRecord))
+
+                // 清理临时文件
+                savedRecord.clearTemporaryAssets(prefix: SyncEngine.temporaryAssetStorage)
             }
 
-            Logger.syncEngine.info("Sent save success record zone: \(savedLocalQueueIds, privacy: .public)")
-            try? storage.runTransaction {
-                try self.storage.syncMetadataUpdate(metadatas, handle: $0)
-                try self.storage.pendingUploadDequeue(by: savedLocalQueueIds, handle: $0)
+            if !queueCandidates.isEmpty || !metadatas.isEmpty {
+                Logger.syncEngine.info("Sent save success record zone candidates: \(queueCandidates, privacy: .public)")
+                try? storage.runTransaction { handle in
+                    if !metadatas.isEmpty {
+                        try self.storage.syncMetadataUpdate(metadatas, handle: handle)
+                    }
+
+                    guard !queueCandidates.isEmpty else { return }
+                    let existingQueues = queueCandidates.filter {
+                        self.storage.pendingUploadExists(queueId: $0.queueId, tableName: $0.tableName, objectId: $0.objectId, handle: handle)
+                    }
+
+                    guard !existingQueues.isEmpty else { return }
+                    try self.storage.pendingUploadDequeue(by: existingQueues, handle: handle)
+                }
             }
         }
 

--- a/Frameworks/Storage/Sources/Storage/Tables/UploadQueue.swift
+++ b/Frameworks/Storage/Sources/Storage/Tables/UploadQueue.swift
@@ -111,7 +111,7 @@ package extension UploadQueue {
     convenience init<T: Syncable>(source: T, changes: Changes) throws {
         self.init()
         objectId = source.objectId
-        deviceId = source.deviceId
+        deviceId = Storage.deviceId
         tableName = T.tableName
         creation = source.creation
         modified = source.modified


### PR DESCRIPTION
Fixes a runaway sync loop by ensuring upload queue entries are correctly associated with the local device and robustly dequeued.

Previously, `UploadQueue` entries sometimes recorded an incorrect `deviceId`, preventing CloudKit acknowledgements from matching and clearing them. This PR forces new entries to use the local device ID, normalizes existing entries on startup, and hardens the dequeuing logic to verify queue ownership via the database, resolving the persistent sync issues, UI regressions, and thermal problems reported by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-2de31105-e9f7-4ffb-91cf-c52ea4b82abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2de31105-e9f7-4ffb-91cf-c52ea4b82abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>