### PR TITLE
fix trait change order

### DIFF
--- a/FlowDown/Interface/RichEditor/Supplement/BlockButton.swift
+++ b/FlowDown/Interface/RichEditor/Supplement/BlockButton.swift
@@ -45,6 +45,7 @@ class BlockButton: UIButton {
 
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _) in
             self.applyDefaultAppearance()
+            self.updateAppearanceAfterTraitChange()
         }
     }
 
@@ -108,4 +109,7 @@ class BlockButton: UIButton {
         )
         textLabel.attributedText = attrText
     }
+
+    /// 给子类留出在 trait change 之后更新 UI 的入口。
+    func updateAppearanceAfterTraitChange() {}
 }

--- a/FlowDown/Interface/RichEditor/Supplement/ToggleBlockButton.swift
+++ b/FlowDown/Interface/RichEditor/Supplement/ToggleBlockButton.swift
@@ -22,10 +22,6 @@ class ToggleBlockButton: BlockButton {
     override init(text: String, icon: String) {
         super.init(text: text, icon: icon)
         super.actionBlock = { [weak self] in self?.toggle() }
-
-        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _) in
-            self.updateUI()
-        }
     }
 
     @available(*, unavailable)
@@ -46,6 +42,11 @@ class ToggleBlockButton: BlockButton {
                 newValue()
             }
         }
+    }
+
+    override func updateAppearanceAfterTraitChange() {
+        super.updateAppearanceAfterTraitChange()
+        updateUI()
     }
 
     func updateUI() {


### PR DESCRIPTION
统一让 BlockButton 监听 traitChange，继承的子类重载，保证调用顺序
解决 BlockButton 有的时候 traitChange 在 ToggleButton 之后触发，把 ToggleButton 的外观重置为默认