### PR TITLE
Refine RichEditor foreground animation handling

### DIFF
--- a/FlowDown/Interface/RichEditor/RichEditor/RichEditorView+Notification.swift
+++ b/FlowDown/Interface/RichEditor/RichEditor/RichEditorView+Notification.swift
@@ -11,4 +11,8 @@ extension RichEditorView {
     @objc func applicationWillResignActive() {
         parentViewController?.view.endEditing(true)
     }
+
+    @objc func applicationDidBecomeActive() {
+        colorfulShadow.refreshAfterReturningToForeground()
+    }
 }

--- a/FlowDown/Interface/RichEditor/RichEditor/RichEditorView.swift
+++ b/FlowDown/Interface/RichEditor/RichEditor/RichEditorView.swift
@@ -12,6 +12,12 @@ class RichEditorView: EditorSectionView {
             name: UIApplication.willResignActiveNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
     }
 
     @available(*, unavailable)

--- a/FlowDown/Interface/RichEditor/Supplement/ColorfulShadowView.swift
+++ b/FlowDown/Interface/RichEditor/Supplement/ColorfulShadowView.swift
@@ -55,6 +55,11 @@ final class ColorfulShadowView: UIView {
         didSet { applyCurrentMode() }
     }
 
+    func refreshAfterReturningToForeground() {
+        gradientView.speed = 1
+        scheduleSpeedStop()
+    }
+
     init() {
         director = SpeckleAnimationRoundedRectangleDirector(
             inset: -0.2,


### PR DESCRIPTION
## Summary
- resume the colorful shadow animation by setting its speed back to 1 when returning to the foreground and reusing the existing stop scheduling logic
- restore the delayed stop handler to halt the animation again after the idle timeout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919f95879408324a6bad92b0540c9e7)