### PR TITLE
Ensure appearance override persists after backgrounding

### DIFF
--- a/FlowDown/Application/AppDelegate.swift
+++ b/FlowDown/Application/AppDelegate.swift
@@ -117,6 +117,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) {}
 
     func applicationDidBecomeActive(_: UIApplication) {
+        UIUserInterfaceStyle.reapplyConfiguredStyle()
         MLX.GPU.onApplicationBecomeActivate()
     }
 

--- a/FlowDown/Application/Value+UserInterfaceStyle.swift
+++ b/FlowDown/Application/Value+UserInterfaceStyle.swift
@@ -84,6 +84,8 @@ extension UIUserInterfaceStyle {
                 }
             }
             .store(in: &cancellables)
+
+        reapplyConfiguredStyle()
     }
 
     static func apply(style: Self) {
@@ -101,5 +103,19 @@ extension UIUserInterfaceStyle {
                 .flatMap(\.windows)
                 .forEach { $0.overrideUserInterfaceStyle = style }
         #endif
+    }
+
+    static func configuredStyle() -> UIUserInterfaceStyle {
+        guard
+            let rawValue: Int = ConfigurableKit.value(forKey: storageKey),
+            let style = UIUserInterfaceStyle(rawValue: rawValue)
+        else {
+            return .unspecified
+        }
+        return style
+    }
+
+    static func reapplyConfiguredStyle() {
+        apply(style: configuredStyle())
     }
 }


### PR DESCRIPTION
## Summary
- add helpers around the appearance configurable to read and reapply the stored interface style
- apply the configured interface style both after subscribing and whenever the app becomes active so the override persists after backgrounding

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919fb782ee483248da2102b6dc3437a)