### PR TITLE
Introduced AppEnvironment to centralize core services

### DIFF
--- a/FlowDown/Backend/Supplement/AppEnvironment.swift
+++ b/FlowDown/Backend/Supplement/AppEnvironment.swift
@@ -1,0 +1,76 @@
+//
+//  AppEnvironment.swift
+//  FlowDown
+//
+//  Created by OpenAI Code Assistant on 2/17/25.
+//
+
+import Foundation
+import Storage
+
+/// Centralizes core services so they can be swapped (for previews/tests) without touching global singletons.
+enum AppEnvironment {
+    struct Container {
+        let storage: Storage
+        let syncEngine: SyncEngine
+    }
+
+    private static var containerStack: [Container] = []
+
+    static var current: Container {
+        guard let container = containerStack.last else {
+            fatalError("Call AppEnvironment.bootstrap(_) before accessing dependencies.")
+        }
+        return container
+    }
+
+    @discardableResult
+    static func bootstrap(_ container: Container) -> Container {
+        containerStack = [container]
+        apply(container)
+        return container
+    }
+
+    static func push(_ container: Container) {
+        containerStack.append(container)
+        apply(container)
+    }
+
+    static func pop() {
+        guard containerStack.count > 1 else {
+            assertionFailure("Attempted to pop the root AppEnvironment container.")
+            return
+        }
+        _ = containerStack.popLast()
+        if let container = containerStack.last {
+            apply(container)
+        }
+    }
+
+    private static func apply(_ container: Container) {
+        Storage.setSyncEngine(container.syncEngine)
+    }
+}
+
+extension AppEnvironment.Container {
+    static func live() -> AppEnvironment.Container {
+        let storage: Storage
+        do {
+            storage = try Storage.db()
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+
+        let syncEngine = SyncEngine(
+            storage: storage,
+            containerIdentifier: CloudKitConfig.containerIdentifier,
+            mode: .live,
+            automaticallySync: true
+        )
+        return .init(storage: storage, syncEngine: syncEngine)
+    }
+}
+
+// Convenience accessors to keep existing call sites small.
+var sdb: Storage { AppEnvironment.current.storage }
+var syncEngine: SyncEngine { AppEnvironment.current.syncEngine }

--- a/FlowDown/main.swift
+++ b/FlowDown/main.swift
@@ -41,6 +41,8 @@ let disposableResourcesDir = FileManager.default
     .temporaryDirectory
     .appendingPathComponent("DisposableResources")
 
+AppEnvironment.bootstrap(.live())
+
 import ConfigurableKit
 import MLX
 
@@ -56,24 +58,6 @@ import MLX
     ConfigurableKit.set(value: true, forKey: MLX.GPU.isSupportedKey)
     assert(MLX.GPU.isSupported)
 #endif
-
-import Storage
-
-let sdb: Storage = {
-    do {
-        return try Storage.db()
-    } catch {
-        fatalError(error.localizedDescription)
-    }
-}()
-
-let syncEngine = SyncEngine(
-    storage: sdb,
-    containerIdentifier: CloudKitConfig.containerIdentifier,
-    mode: .live,
-    automaticallySync: true
-)
-Storage.setSyncEngine(syncEngine)
 
 _ = ModelManager.shared
 _ = ModelToolsManager.shared


### PR DESCRIPTION
 - Added FlowDown/Backend/Supplement/AppEnvironment.swift, a tiny dependency container that owns Storage
    and SyncEngine, updates Storage.setSyncEngine automatically, and still exposes the familiar sdb/
    syncEngine accessors. Push/pop makes it trivial to swap in temporary stores or stub sync engines for
    tests and previews.
  - Bootstrapped startup in FlowDown/main.swift via AppEnvironment.bootstrap(.live()), replacing inline
    globals with an intentional handoff. Behavior stays identical, but wiring is now explicit and
    swappable.

  Why it’s better: Dependencies are no longer baked into main.swift, so tests can run with isolated
  storage, future services have a clear path, and platform-specific variants can opt into different
  containers without touching app logic—all while keeping today’s code paths intact.