### PR TITLE
feat(model): add reasoning effort presets

### DIFF
--- a/FlowDown/Resources/Localizable.xcstrings
+++ b/FlowDown/Resources/Localizable.xcstrings
@@ -57110,6 +57110,52 @@
           }
         }
       }
+    },
+    "Reasoning Effort" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reasoning Effort"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reasoning-Aufwand"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esfuerzo de razonamiento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effort de raisonnement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推論の労力"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추론 노력"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推理强度"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Resources/DevKit/scripts/update_missing_i18n.py
+++ b/Resources/DevKit/scripts/update_missing_i18n.py
@@ -17,7 +17,16 @@ from i18n_tools import (
 
 # Populate this map with explicit translations when introducing new keys.
 # Format: {"Key": {"zh-Hans": "示例", "es": "Ejemplo"}}
-NEW_STRINGS: dict[str, dict[str, str]] = { }
+NEW_STRINGS: dict[str, dict[str, str]] = {
+    "Reasoning Effort": {
+        "de": "Reasoning-Aufwand",
+        "es": "Esfuerzo de razonamiento",
+        "fr": "Effort de raisonnement",
+        "ja": "推論の労力",
+        "ko": "추론 노력",
+        "zh-Hans": "推理强度",
+    },
+}
 
 if __name__ == "__main__":
     file_path = sys.argv[1] if len(sys.argv) > 1 else default_file_path()
@@ -31,4 +40,3 @@ if __name__ == "__main__":
     save_strings(file_path, data)
 
     print_update_summary(file_path, counts)
-


### PR DESCRIPTION
### Summary

This PR decouples **“reasoning budget”** (token-based) from **“reasoning effort”** (effort-based) in the Cloud Model → Networking (Advanced) → Body Fields editor, allowing users to choose the parameter style that matches their specific provider or model.

### Background / Problem

Previously, the editor only exposed a token-based preset menu (512/1024/4096/8192). The internal enum name `ReasoningEffort` was misleading: it appeared to be an “effort” selector but actually only controlled token budgets (`thinking_budget` or `reasoning.max_tokens`). Providers supporting `reasoning.effort` required users to manually enter JSON.

### What’s changed

*   **Refactored Enums**: Renamed the token preset enum to `ReasoningBudgetPreset` to reflect its true purpose without changing existing behavior.
*   **New Reasoning Effort Menu**: Added a dedicated menu with presets: `xhigh`, `high`, `medium`, `low`, `minimal`, and `none`.
    *   Selecting a preset automatically updates `reasoning.effort` in Body Fields (e.g., `{"reasoning":{"effort":"high"}}`).
    *   Smart Merging: It merges into existing `reasoning` objects if they exist.
    *   Conflict Detection: If conflicting keys (like `thinking_mode` or `enable_thinking`) are detected, the UI prompts the user to replace them.
*   **Localization**: Added full localization for the new "Reasoning Effort" menu title across supported languages (de, es, fr, ja, ko, zh-Hans) via the i18n script.

### Why this is better

*   **Explicit Separation**: Effort and Budget are now distinct options. Token budgets remain available for providers using `thinking_budget`, while effort presets support providers using `reasoning.effort`.
*   **Improved UX**: Users can configure model-specific reasoning parameters via the UI without manual JSON entry.

### Testing

*   **Manual Verification**: Navigate to Cloud Model → Networking (Advanced) → Body Fields → Menu → Reasoning Parameters. Select a "Reasoning Effort" preset and verify that the JSON updates correctly.
*   **Regression Testing**: Confirmed that existing request-building behavior is unchanged; Body Fields continue to merge into outgoing requests as expected.