### PR TITLE
refactor(model): localize reasoning effort titles

### DIFF
--- a/FlowDown/Interface/SettingController/Model/ModelEditorController/CloudModelEditorController+BodyFieldsMenu.swift
+++ b/FlowDown/Interface/SettingController/Model/ModelEditorController/CloudModelEditorController+BodyFieldsMenu.swift
@@ -70,6 +70,8 @@ extension CloudModelEditorController {
         case low
         case minimal
         case none
+
+        var title: String.LocalizationValue { "Set \("reasoning.effort") to \(rawValue)" }
     }
 
     func buildExtraBodyEditorMenu(controller: JsonEditorController) -> UIMenu {
@@ -139,15 +141,15 @@ extension CloudModelEditorController {
                 )
             }
 
-            let budgetActions = ReasoningBudgetPreset.allCases.map { effort in
-                UIAction(title: String(localized: effort.title)) { _ in
+            let budgetActions = ReasoningBudgetPreset.allCases.map { preset in
+                UIAction(title: String(localized: preset.title)) { _ in
                     controller.updateValue { dictionary in
                         switch key {
                         case .thinkingMode, .thinking, .enableThinking:
-                            dictionary["thinking_budget"] = effort.thinkingBudgetTokens
+                            dictionary["thinking_budget"] = preset.thinkingBudgetTokens
                         case .reasoning:
                             var value = dictionary[key.rawValue, default: [:]] as? [String: Any] ?? [:]
-                            value["max_tokens"] = effort.thinkingBudgetTokens
+                            value["max_tokens"] = preset.thinkingBudgetTokens
                             dictionary[key.rawValue] = value
                         }
                     }
@@ -164,7 +166,7 @@ extension CloudModelEditorController {
         let reasoningEffortMenu: UIMenu = {
             let effortActions = ReasoningEffortPreset.allCases.map { effort -> UIAction in
                 UIAction(
-                    title: String(localized: "Set \("reasoning.effort") to \(effort.rawValue)"),
+                    title: String(localized: effort.title),
                     image: UIImage(systemName: "bolt.circle"),
                 ) { _ in
                     let dictionary = controller.currentDictionary


### PR DESCRIPTION
### Summary
Minor follow-up to the reasoning effort presets PR: improve localization and naming clarity in the Body Fields menu.

### Changes
- Rename the ReasoningBudgetPreset loop variable from effort → preset to prevent confusion with the new effort presets.