### PR TITLE
Fix settings path in chat templates documentation

### DIFF
--- a/LandingPage/src/app/docs/documents/configuration/chat_templates.md
+++ b/LandingPage/src/app/docs/documents/configuration/chat_templates.md
@@ -1,11 +1,11 @@
 # Chat Templates
 
-Chat templates seed new conversations with consistent system prompts and a recognizable emoji avatar. Each template stores its name, emoji, system prompt, and whether it inherits the app-level prompt. Templates do not capture tool selections, starter messages, or model preferences.
+Chat templates seed new conversations with consistent system prompts and a recognizable emoji avatar. Each template stores its name, emoji, system prompt, and whether it inherits the app-level prompt. Templates do not capture tool selections, starter messages, or inference preferences.
 
 ## Create or Import
 
-- **Generate from an active conversation**: Open the conversation menu and choose **Generate Chat Template**. FlowDown uses the current chat model to extract a name, emoji, and prompt from recent exchanges (needs at least one user and one assistant message) and saves it to **Settings → Models → Chat Template**.
-- **Create from scratch**: Go to **Settings → Models → Chat Template** and tap **＋ → Create Template** to start with a blank template.
+- **Generate from an active conversation**: Open the conversation menu and choose **Generate Chat Template**. FlowDown uses the current chat model to extract a name, emoji, and prompt from recent exchanges (needs at least one user and one assistant message) and saves it to **Settings → Inference → Chat Template**.
+- **Create from scratch**: Go to **Settings → Inference → Chat Template** and tap **＋ → Create Template** to start with a blank template.
 - **Rewrite an existing template**: In the template editor, tap the sparkle button to have the default chat model rewrite the prompt based on your instructions.
 - **Import**: In the template list, choose **＋ → Import from File** to load `.fdtemplate` files (supports multi-select). You can also drag and drop `.fdtemplate` files into the list or open them from Finder/Share to import; templates with the same identifier are replaced.
 


### PR DESCRIPTION
Updated references from 'Settings → Models → Chat Template' to 'Settings → Inference → Chat Template' for clarity.