### PR TITLE
Download MetalToolchain before CI xcodebuild steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Resolve Packages (${{ matrix.target }})
         run: |
           set -o pipefail
+          xcodebuild -downloadComponent MetalToolchain
           xcodebuild \
             -workspace FlowDown.xcworkspace \
             -scheme "${{ matrix.scheme }}" \
@@ -56,6 +57,7 @@ jobs:
       - name: Archive (${{ matrix.target }})
         run: |
           set -o pipefail
+          xcodebuild -downloadComponent MetalToolchain
           mkdir -p BuildArtifacts
           xcodebuild \
             -workspace FlowDown.xcworkspace \

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -121,6 +121,7 @@ jobs:
         if: steps.check.outputs.has_updates == 'true' || steps.licenses.outputs.has_license_updates == 'true'
         run: |
           set -o pipefail
+          xcodebuild -downloadComponent MetalToolchain
           xcodebuild \
             -workspace FlowDown.xcworkspace \
             -scheme FlowDown \
@@ -140,6 +141,7 @@ jobs:
         if: steps.check.outputs.has_updates == 'true' || steps.licenses.outputs.has_license_updates == 'true'
         run: |
           set -o pipefail
+          xcodebuild -downloadComponent MetalToolchain
           DESTINATION=$(bash Resources/DevKit/scripts/get_first_ios_simulator.sh)
           xcodebuild \
             -workspace FlowDown.xcworkspace \
@@ -156,6 +158,7 @@ jobs:
         if: steps.check.outputs.has_updates == 'true' || steps.licenses.outputs.has_license_updates == 'true'
         run: |
           set -o pipefail
+          xcodebuild -downloadComponent MetalToolchain
           DESTINATION=$(bash Resources/DevKit/scripts/get_first_ios_simulator.sh)
           xcodebuild \
             -workspace FlowDown.xcworkspace \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Resolve Packages
         run: |
           set -o pipefail
+          xcodebuild -downloadComponent MetalToolchain
           xcodebuild \
             -workspace FlowDown.xcworkspace \
             -scheme FlowDown \
@@ -61,6 +62,7 @@ jobs:
       - name: Build FlowDown (for codegen)
         run: |
           set -o pipefail
+          xcodebuild -downloadComponent MetalToolchain
           DESTINATION=$(bash Resources/DevKit/scripts/get_first_ios_simulator.sh)
           xcodebuild \
             -workspace FlowDown.xcworkspace \
@@ -76,6 +78,7 @@ jobs:
       - name: Run Unit Tests
         run: |
           set -o pipefail
+          xcodebuild -downloadComponent MetalToolchain
           DESTINATION=$(bash Resources/DevKit/scripts/get_first_ios_simulator.sh)
           xcodebuild \
             -workspace FlowDown.xcworkspace \


### PR DESCRIPTION
## Summary
- add `xcodebuild -downloadComponent MetalToolchain` before all CI xcodebuild invocations
- cover build, test, and housekeeping workflows to avoid missing Metal toolchain failures

## Verification
- validated via branch rebases that all active fix PRs now include this commit
- CI will execute in GitHub Actions