### PR TITLE
Patch Inline Math Placeholder Leakage

### DIFF
--- a/FlowDown/Extension/MarkdownParser+MathPlaceholderRepair.swift
+++ b/FlowDown/Extension/MarkdownParser+MathPlaceholderRepair.swift
@@ -1,0 +1,93 @@
+//
+//  MarkdownParser+MathPlaceholderRepair.swift
+//  FlowDown
+//
+//  Created by Codex on 2026/2/22.
+//
+
+import MarkdownParser
+
+extension MarkdownParser.ParseResult {
+    func documentByRepairingInlineMathPlaceholders() -> [MarkdownBlockNode] {
+        document.map { repair(block: $0, mathContext: mathContext) }
+    }
+
+    private func repair(block: MarkdownBlockNode, mathContext: [Int: String]) -> MarkdownBlockNode {
+        switch block {
+        case let .blockquote(children):
+            return .blockquote(children: children.map { repair(block: $0, mathContext: mathContext) })
+        case let .bulletedList(isTight, items):
+            let repairedItems = items.map { item in
+                RawListItem(children: item.children.map { repair(block: $0, mathContext: mathContext) })
+            }
+            return .bulletedList(isTight: isTight, items: repairedItems)
+        case let .numberedList(isTight, start, items):
+            let repairedItems = items.map { item in
+                RawListItem(children: item.children.map { repair(block: $0, mathContext: mathContext) })
+            }
+            return .numberedList(isTight: isTight, start: start, items: repairedItems)
+        case let .taskList(isTight, items):
+            let repairedItems = items.map { item in
+                RawTaskListItem(
+                    isCompleted: item.isCompleted,
+                    children: item.children.map { repair(block: $0, mathContext: mathContext) }
+                )
+            }
+            return .taskList(isTight: isTight, items: repairedItems)
+        case let .paragraph(content):
+            return .paragraph(content: repairInlineNodes(content, mathContext: mathContext))
+        case let .heading(level, content):
+            return .heading(level: level, content: repairInlineNodes(content, mathContext: mathContext))
+        case let .table(columnAlignments, rows):
+            let repairedRows = rows.map { row in
+                let repairedCells = row.cells.map { cell in
+                    RawTableCell(content: repairInlineNodes(cell.content, mathContext: mathContext))
+                }
+                return RawTableRow(cells: repairedCells)
+            }
+            return .table(columnAlignments: columnAlignments, rows: repairedRows)
+        case .codeBlock, .thematicBreak:
+            return block
+        }
+    }
+
+    private func repairInlineNodes(_ nodes: [MarkdownInlineNode], mathContext: [Int: String]) -> [MarkdownInlineNode] {
+        nodes.map { repair(inlineNode: $0, mathContext: mathContext) }
+    }
+
+    private func repair(inlineNode: MarkdownInlineNode, mathContext: [Int: String]) -> MarkdownInlineNode {
+        switch inlineNode {
+        case let .code(content):
+            return mathNodeFromReplacementCode(content, mathContext: mathContext) ?? inlineNode
+        case let .emphasis(children):
+            return .emphasis(children: repairInlineNodes(children, mathContext: mathContext))
+        case let .strong(children):
+            return .strong(children: repairInlineNodes(children, mathContext: mathContext))
+        case let .strikethrough(children):
+            return .strikethrough(children: repairInlineNodes(children, mathContext: mathContext))
+        case let .link(destination, children):
+            return .link(destination: destination, children: repairInlineNodes(children, mathContext: mathContext))
+        case let .image(source, children):
+            return .image(source: source, children: repairInlineNodes(children, mathContext: mathContext))
+        default:
+            return inlineNode
+        }
+    }
+
+    private func mathNodeFromReplacementCode(_ content: String, mathContext: [Int: String]) -> MarkdownInlineNode? {
+        guard MarkdownParser.typeForReplacementText(content) == .math else { return nil }
+        guard let identifier = MarkdownParser.identifierForReplacementText(content),
+              let index = Int(identifier),
+              let latex = mathContext[index]
+        else {
+            return nil
+        }
+        return .math(
+            content: latex,
+            replacementIdentifier: MarkdownParser.replacementText(
+                for: .math,
+                identifier: identifier
+            )
+        )
+    }
+}

--- a/FlowDown/Interface/MessageListView/MessageListView+NodesCache.swift
+++ b/FlowDown/Interface/MessageListView/MessageListView+NodesCache.swift
@@ -36,7 +36,14 @@ extension MessageListView {
         private func updateCache(for message: MessageRepresentation, theme: MarkdownTheme, contentHash: Int) -> MarkdownTextView.PreprocessedContent {
             let content = message.content
             let result = MarkdownParser().parse(content)
-            let package = MarkdownTextView.PreprocessedContent(parserResult: result, theme: theme)
+            let blocks = result.documentByRepairingInlineMathPlaceholders()
+            let rendered: RenderedTextContent.Map = result.render(theme: theme)
+            let highlightMaps: [Int: CodeHighlighter.HighlightMap] = result.render(theme: theme)
+            let package = MarkdownTextView.PreprocessedContent(
+                blocks: blocks,
+                rendered: rendered,
+                highlightMaps: highlightMaps
+            )
 
             lock.lock()
             cache[message.id] = package

--- a/FlowDown/Interface/SettingController/Model/ModelDownloadController/HubModelDetailController.swift
+++ b/FlowDown/Interface/SettingController/Model/ModelDownloadController/HubModelDetailController.swift
@@ -67,7 +67,14 @@ class HubModelDetailController: StackScrollController {
         let result = MarkdownParser().parse(markdown)
         var theme = MarkdownTheme()
         theme.align(to: UIFont.preferredFont(forTextStyle: .subheadline).pointSize)
-        let package = MarkdownTextView.PreprocessedContent(parserResult: result, theme: theme)
+        let blocks = result.documentByRepairingInlineMathPlaceholders()
+        let rendered: RenderedTextContent.Map = result.render(theme: theme)
+        let highlightMaps: [Int: CodeHighlighter.HighlightMap] = result.render(theme: theme)
+        let package = MarkdownTextView.PreprocessedContent(
+            blocks: blocks,
+            rendered: rendered,
+            highlightMaps: highlightMaps
+        )
         let markdownView = MarkdownTextView().with {
             $0.theme = theme
             $0.bindContentOffset(from: scrollView)

--- a/FlowDownUnitTests/MarkdownMathPlaceholderRepairTests.swift
+++ b/FlowDownUnitTests/MarkdownMathPlaceholderRepairTests.swift
@@ -1,0 +1,106 @@
+@testable import FlowDown
+import MarkdownParser
+import Testing
+
+@Suite
+final class MarkdownMathPlaceholderRepairTests {
+    @Test("Repair keeps math placeholders from leaking inside strong text")
+    func repairStrongInlineMathPlaceholder() {
+        let markdown = "**Conclusion: for points outside a uniform thin spherical shell, gravity is equivalent to placing total shell mass \\\\(M_s\\\\) at the center.**"
+        let result = MarkdownParser().parse(markdown)
+
+        #expect(containsMathPlaceholderCode(in: result.document))
+
+        let repaired = result.documentByRepairingInlineMathPlaceholders()
+        #expect(!containsMathPlaceholderCode(in: repaired))
+        #expect(containsMathNode(in: repaired))
+    }
+
+    @Test("Repair handles nested inline containers")
+    func repairNestedInlineMathPlaceholder() {
+        let markdown = "_See **\\(a^2+b^2=c^2\\)** for the proof._"
+        let result = MarkdownParser().parse(markdown)
+
+        #expect(containsMathPlaceholderCode(in: result.document))
+
+        let repaired = result.documentByRepairingInlineMathPlaceholders()
+        #expect(!containsMathPlaceholderCode(in: repaired))
+        #expect(containsMathNode(in: repaired))
+    }
+}
+
+private func containsMathPlaceholderCode(in blocks: [MarkdownBlockNode]) -> Bool {
+    blocks.contains { block in
+        switch block {
+        case let .blockquote(children):
+            return containsMathPlaceholderCode(in: children)
+        case let .bulletedList(_, items):
+            return items.contains { containsMathPlaceholderCode(in: $0.children) }
+        case let .numberedList(_, _, items):
+            return items.contains { containsMathPlaceholderCode(in: $0.children) }
+        case let .taskList(_, items):
+            return items.contains { containsMathPlaceholderCode(in: $0.children) }
+        case let .paragraph(content), let .heading(_, content):
+            return containsMathPlaceholderCode(in: content)
+        case let .table(_, rows):
+            return rows.contains { row in
+                row.cells.contains { containsMathPlaceholderCode(in: $0.content) }
+            }
+        case .codeBlock, .thematicBreak:
+            return false
+        }
+    }
+}
+
+private func containsMathPlaceholderCode(in nodes: [MarkdownInlineNode]) -> Bool {
+    nodes.contains { node in
+        switch node {
+        case let .code(content):
+            return MarkdownParser.typeForReplacementText(content) == .math
+        case let .emphasis(children), let .strong(children), let .strikethrough(children):
+            return containsMathPlaceholderCode(in: children)
+        case let .link(_, children), let .image(_, children):
+            return containsMathPlaceholderCode(in: children)
+        default:
+            return false
+        }
+    }
+}
+
+private func containsMathNode(in blocks: [MarkdownBlockNode]) -> Bool {
+    blocks.contains { block in
+        switch block {
+        case let .blockquote(children):
+            return containsMathNode(in: children)
+        case let .bulletedList(_, items):
+            return items.contains { containsMathNode(in: $0.children) }
+        case let .numberedList(_, _, items):
+            return items.contains { containsMathNode(in: $0.children) }
+        case let .taskList(_, items):
+            return items.contains { containsMathNode(in: $0.children) }
+        case let .paragraph(content), let .heading(_, content):
+            return containsMathNode(in: content)
+        case let .table(_, rows):
+            return rows.contains { row in
+                row.cells.contains { containsMathNode(in: $0.content) }
+            }
+        case .codeBlock, .thematicBreak:
+            return false
+        }
+    }
+}
+
+private func containsMathNode(in nodes: [MarkdownInlineNode]) -> Bool {
+    nodes.contains { node in
+        switch node {
+        case .math(_, _):
+            return true
+        case let .emphasis(children), let .strong(children), let .strikethrough(children):
+            return containsMathNode(in: children)
+        case let .link(_, children), let .image(_, children):
+            return containsMathNode(in: children)
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Repair markdown parser results in FlowDown by recursively converting leaked math placeholder code spans back into math nodes before rendering.

Apply the repaired document in chat and model detail markdown rendering paths and add regression tests for strong and nested inline math cases.