### PR TITLE
Fix iPad Split View minimum size restriction

### DIFF
--- a/FlowDown/Application/SceneDelegate.swift
+++ b/FlowDown/Application/SceneDelegate.swift
@@ -28,8 +28,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 titlebar.titleVisibility = .hidden
                 titlebar.toolbar = nil
             }
+            windowScene.sizeRestrictions?.minimumSize = CGSize(width: 650, height: 650)
         #endif
-        windowScene.sizeRestrictions?.minimumSize = CGSize(width: 650, height: 650)
         let window = UIWindow(windowScene: windowScene)
         defer {
             window.makeKeyAndVisible()


### PR DESCRIPTION
## Summary
- Moves `sizeRestrictions?.minimumSize` inside the existing `#if targetEnvironment(macCatalyst)` block so it only applies on macOS, not iPadOS
- Allows iPadOS Split View (1/3, 1/2, 2/3) and Slide Over to freely resize the app window
- Preserves the 650×650pt minimum on macCatalyst desktop windows

Closes #246

## Test plan
- [ ] Build and run on iPad simulator — enter Split View and verify the window can be dragged to the narrow 1/3 column
- [ ] Test Slide Over — verify FlowDown works in the Slide Over panel (~414pt wide)
- [ ] Verify the sidebar collapses and compact layout activates at narrow widths (<500pt)
- [ ] Build and run on macCatalyst — verify the 650×650pt minimum window size still applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)