### PR TITLE
Bump ChatClientKit to 2.4.5 (fix #273 + strip assistant reasoning)

### DIFF
--- a/FlowDownUnitTests/OnlineE2ETestSupport.swift
+++ b/FlowDownUnitTests/OnlineE2ETestSupport.swift
@@ -14,7 +14,7 @@ enum OnlineE2ETestSupport {
     // headers, body fields, and capabilities below track the exported
     // kimi-k2p5-turbo .fdmodel but can still be overridden via env.
     private static let embeddedFixture = EmbeddedCloudModelFixture(
-        modelIdentifier: "kimi-k2p5-turbo",
+        modelIdentifier: "kimi-k2p6-turbo",
         headers: [
             "HTTP-Referer": "https://flowdown.ai/",
             "X-Title": "FlowDown",

--- a/FlowDownUnitTests/OnlineReasoningStrippingE2ETests.swift
+++ b/FlowDownUnitTests/OnlineReasoningStrippingE2ETests.swift
@@ -1,0 +1,75 @@
+//
+//  OnlineReasoningStrippingE2ETests.swift
+//  FlowDownUnitTests
+//
+//  E2E coverage for the reasoning strip in chat-completions requests.
+//  When a reasoning-capable provider returns `reasoning_content` and the
+//  app echoes it back on the next turn, providers like DeepSeek (and
+//  Moonshot's Kimi-Turbo) reject the request. This suite walks the full
+//  round trip and asserts the follow-up turn succeeds.
+//
+
+@testable import ChatClientKit
+@testable import FlowDown
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct OnlineReasoningStrippingE2ETests {
+    @Test(.enabled(if: OnlineE2ETestSupport.isEnabled))
+    func `Reasoning content is captured for a reasoning-capable model`() async throws {
+        let client = try OnlineE2ETestSupport.makeCompletionsClient()
+        let body = ChatRequestBody(
+            messages: [
+                .user(content: .text("Say hello in one sentence.")),
+            ],
+            maxCompletionTokens: 512,
+        )
+
+        let response = try await client.chat(body: body)
+
+        if response.reasoning.isEmpty, response.text.isEmpty {
+            Issue.record("Provider returned no text or reasoning content; cannot validate reasoning capture.")
+            return
+        }
+        #expect(!response.text.isEmpty)
+    }
+
+    @Test(.enabled(if: OnlineE2ETestSupport.isEnabled))
+    func `Follow-up turn succeeds when prior reasoning is retained on assistant message`() async throws {
+        let client = try OnlineE2ETestSupport.makeCompletionsClient()
+
+        let firstBody = ChatRequestBody(
+            messages: [
+                .user(content: .text("Briefly explain why the sky is blue, in one sentence.")),
+            ],
+            maxCompletionTokens: 512,
+        )
+
+        let firstResponse = try await client.chat(body: firstBody)
+        #expect(!firstResponse.text.isEmpty)
+
+        // Echo the prior assistant turn back, including reasoning. Pre-fix,
+        // the encoder shipped a `reasoning` field in the assistant message
+        // and providers like Moonshot Kimi-Turbo rejected the request with
+        // an HTTP error. Post-fix, the encoder drops the field on the wire
+        // and the request succeeds.
+        let secondBody = ChatRequestBody(
+            messages: [
+                .user(content: .text("Briefly explain why the sky is blue, in one sentence.")),
+                .assistant(
+                    content: .text(firstResponse.text),
+                    toolCalls: nil,
+                    reasoning: firstResponse.reasoning.isEmpty
+                        ? "Synthetic reasoning trace for regression coverage."
+                        : firstResponse.reasoning,
+                ),
+                .user(content: .text("Now restate that in five words or fewer.")),
+            ],
+            maxCompletionTokens: 512,
+        )
+
+        let secondResponse = try await client.chat(body: secondBody)
+        #expect(!secondResponse.text.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Bumps the ChatClientKit submodule to 2.4.5, bundling two fixes.

### 2.4.4 — stable tool schema serialization (fixes #273)
Tool parameter dictionaries used hash-randomized key order between turns, breaking prompt prefix caching on llama.cpp and similar servers. The submodule release switches both completion and responses request builders to a sorted-keys JSONEncoder, sorts the additional-field merge path, sorts `AnyCodingValue` object encoding, and locks the Apple Intelligence schema description to the same encoder.

### 2.4.5 — strip reasoning from chat-completions assistant messages
The OpenAI chat-completions wire schema does not accept a reasoning field on assistant turns, and providers like DeepSeek explicitly fail the request when prior reasoning is echoed back on a follow-up turn. The domain model still carries reasoning for local persistence and UI; the encoder now drops it instead of serializing it.

Fixes #273.

## Test plan
- [x] ChatClientKitTests — 89 tests across 21 suites pass via xcodebuild on iPhone 16 simulator
- [ ] Manual: chat with a reasoning-capable model (e.g. DeepSeek-R1 via OpenRouter), confirm that the second turn no longer fails with a reasoning-related rejection
- [ ] Manual: confirm tool-enabled chat requests produce byte-identical JSON across turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)