### PR TITLE
Integrate ReminderTools with EventKit and enhance localization

### DIFF
--- a/FlowDown/Backend/MCPService/MCPService.swift
+++ b/FlowDown/Backend/MCPService/MCPService.swift
@@ -186,7 +186,7 @@ class MCPService: NSObject {
         }
 
         let eligibleServerIds = Set(eligibleServers.map(\.id))
-        for (serverId, connection) in connections {
+        for (serverId, connection) in Array(connections) {
             if !eligibleServerIds.contains(serverId) {
                 connection.disconnect()
                 connections.removeValue(forKey: serverId)

--- a/FlowDown/Backend/ModelTools/ModelToolsManager.swift
+++ b/FlowDown/Backend/ModelTools/ModelToolsManager.swift
@@ -40,6 +40,12 @@ class ModelToolsManager {
                 MTAddCalendarTool(),
                 MTQueryCalendarTool(),
 
+                MTAddReminderTool(),
+                MTQueryReminderTool(),
+                MTUpdateReminderTool(),
+                MTCompleteReminderTool(),
+                MTDeleteReminderTool(),
+
                 MTWebScraperTool(),
                 MTWebSearchTool(),
 
@@ -57,6 +63,12 @@ class ModelToolsManager {
             tools = [
                 MTAddCalendarTool(),
                 MTQueryCalendarTool(),
+
+                MTAddReminderTool(),
+                MTQueryReminderTool(),
+                MTUpdateReminderTool(),
+                MTCompleteReminderTool(),
+                MTDeleteReminderTool(),
 
                 MTWebScraperTool(),
                 MTWebSearchTool(),
@@ -145,6 +157,7 @@ class ModelToolsManager {
             if tool is MTListMemoriesTool { return false }
             if tool is MTUpdateMemoryTool { return false }
             if tool is MTDeleteMemoryTool { return false }
+            if tool is MTCompleteReminderTool { return false }
             return true
         }
     }

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTAddReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTAddReminderTool.swift
@@ -128,11 +128,11 @@ class MTAddReminderTool: ModelTool, @unchecked Sendable {
             ReminderToolsShared.requestAccess { [weak self] granted in
                 Task { @MainActor in
                     guard let self else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.internalError("Reminder tool was deallocated before completion."))
                         return
                     }
                     guard granted else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.authorizationDeniedError())
                         return
                     }
                     self.showConfirmation(
@@ -200,12 +200,16 @@ class MTAddReminderTool: ModelTool, @unchecked Sendable {
                         )
                     }
                     if priority != 0 { reminder.priority = priority }
-                    reminder.calendar = ReminderToolsShared.resolveCalendar(named: listName, eventStore: eventStore)
-
                     do {
+                        reminder.calendar = try ReminderToolsShared.resolveCalendarRequiringName(
+                            named: listName,
+                            eventStore: eventStore,
+                        )
                         try eventStore.save(reminder, commit: true)
                         let id = reminder.calendarItemIdentifier
                         continuation.resume(returning: String(localized: "Reminder added: \(title) [id: \(id)]"))
+                    } catch let error as NSError where error.domain == ReminderToolsShared.errorDomain {
+                        continuation.resume(throwing: error)
                     } catch {
                         continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
                             NSLocalizedDescriptionKey: String(localized: "Failed to add reminder: \(error.localizedDescription)"),

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTAddReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTAddReminderTool.swift
@@ -1,0 +1,234 @@
+//
+//  MTAddReminderTool.swift
+//  FlowDown
+//
+//  Created by XZB-1248 on 5/10/26.
+//
+
+import AlertController
+import ChatClientKit
+import ConfigurableKit
+import EventKit
+import Foundation
+import UIKit
+
+class MTAddReminderTool: ModelTool, @unchecked Sendable {
+    override var shortDescription: String {
+        "create a new reminder in user's system Reminders"
+    }
+
+    override var interfaceName: String {
+        String(localized: "Add to Reminders")
+    }
+
+    override var definition: ChatRequestBody.Tool {
+        .function(
+            name: "add_reminder",
+            description: """
+            Creates a new reminder in the user's system Reminders. Provide a title and any optional fields. Convert all dates to ISO 8601 UTC (yyyy-MM-dd'T'HH:mm:ss'Z') yourself; do not ask the user.
+            Priority follows EKReminder convention: 0 = no priority, 1 = high, 5 = medium, 9 = low.
+            Pass an empty string for optional text fields and an empty string for due_date when not set. Pass 0 for priority when not set. Pass an empty list_name to use the default Reminders list.
+            """,
+            parameters: [
+                "type": "object",
+                "properties": [
+                    "title": [
+                        "type": "string",
+                        "description": "Title of the reminder. Required and must be non-empty.",
+                    ],
+                    "notes": [
+                        "type": "string",
+                        "description": "Free-form notes for the reminder. Pass empty string for none.",
+                    ],
+                    "due_date": [
+                        "type": "string",
+                        "description": "Due date in ISO 8601 UTC (yyyy-MM-dd'T'HH:mm:ss'Z'). Pass empty string for no due date.",
+                    ],
+                    "priority": [
+                        "type": "integer",
+                        "description": "EKReminder priority (0 = none, 1 = high, 5 = medium, 9 = low).",
+                    ],
+                    "list_name": [
+                        "type": "string",
+                        "description": "Name of the Reminders list (calendar) to add to. Pass empty string for the default list.",
+                    ],
+                ],
+                "required": ["title", "notes", "due_date", "priority", "list_name"],
+                "additionalProperties": false,
+            ],
+            strict: true,
+        )
+    }
+
+    override class var controlObject: ConfigurableObject {
+        .init(
+            icon: "checklist",
+            title: "Add to Reminders",
+            explain: "Allows LLM to create reminders in your system Reminders.",
+            key: "wiki.qaq.ModelTools.AddReminderTool.enabled",
+            defaultValue: true,
+            annotation: .toggle,
+        )
+    }
+
+    override func execute(with input: String, anchorTo view: UIView) async throws -> String {
+        guard let data = input.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let title = json["title"] as? String, !title.isEmpty
+        else {
+            throw NSError(
+                domain: "MTAddReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "A non-empty title is required."),
+                ],
+            )
+        }
+
+        let notes = (json["notes"] as? String) ?? ""
+        let dueDateString = (json["due_date"] as? String) ?? ""
+        let priority = (json["priority"] as? Int) ?? 0
+        let listName = (json["list_name"] as? String) ?? ""
+
+        let dueDate: Date? = dueDateString.isEmpty ? nil : ReminderToolsShared.parseISODate(dueDateString)
+        if !dueDateString.isEmpty, dueDate == nil {
+            throw NSError(
+                domain: "MTAddReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Invalid due_date format. Use ISO 8601 UTC."),
+                ],
+            )
+        }
+
+        guard let viewController = await view.parentViewController else {
+            throw NSError(
+                domain: "MTAddReminderTool", code: 500, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Could not find view controller"),
+                ],
+            )
+        }
+
+        return try await addWithUserInteraction(
+            title: title,
+            notes: notes,
+            dueDate: dueDate,
+            priority: priority,
+            listName: listName,
+            controller: viewController,
+        )
+    }
+
+    @MainActor
+    private func addWithUserInteraction(
+        title: String,
+        notes: String,
+        dueDate: Date?,
+        priority: Int,
+        listName: String,
+        controller: UIViewController,
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { cont in
+            ReminderToolsShared.requestAccess { [weak self] granted in
+                Task { @MainActor in
+                    guard let self else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+                    guard granted else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+                    self.showConfirmation(
+                        title: title,
+                        notes: notes,
+                        dueDate: dueDate,
+                        priority: priority,
+                        listName: listName,
+                        controller: controller,
+                        continuation: cont,
+                    )
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func showConfirmation(
+        title: String,
+        notes: String,
+        dueDate: Date?,
+        priority: Int,
+        listName: String,
+        controller: UIViewController,
+        continuation: CheckedContinuation<String, any Swift.Error>,
+    ) {
+        var lines = [String(localized: "Title: \(title)")]
+        if !notes.isEmpty {
+            lines.append(String(localized: "Notes: \(notes)"))
+        }
+        if let dueDate {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .short
+            lines.append(String(localized: "Due: \(formatter.string(from: dueDate))"))
+        }
+        if priority != 0 {
+            lines.append(String(localized: "Priority: \(ReminderToolsShared.priorityLabel(priority))"))
+        }
+        if !listName.isEmpty {
+            lines.append(String(localized: "List: \(listName)"))
+        }
+
+        let alert = AlertViewController(
+            title: "Add to Reminders",
+            message: lines.joined(separator: "\n"),
+        ) { context in
+            context.addAction(title: "Cancel") {
+                context.dispose {
+                    continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                        NSLocalizedDescriptionKey: String(localized: "User cancelled the operation."),
+                    ]))
+                }
+            }
+            context.addAction(title: "Add", attribute: .accent) {
+                context.dispose {
+                    let eventStore = EKEventStore()
+                    let reminder = EKReminder(eventStore: eventStore)
+                    reminder.title = title
+                    if !notes.isEmpty { reminder.notes = notes }
+                    if let dueDate {
+                        reminder.dueDateComponents = Calendar.current.dateComponents(
+                            [.year, .month, .day, .hour, .minute],
+                            from: dueDate,
+                        )
+                    }
+                    if priority != 0 { reminder.priority = priority }
+                    reminder.calendar = ReminderToolsShared.resolveCalendar(named: listName, eventStore: eventStore)
+
+                    do {
+                        try eventStore.save(reminder, commit: true)
+                        let id = reminder.calendarItemIdentifier
+                        continuation.resume(returning: String(localized: "Reminder added: \(title) [id: \(id)]"))
+                    } catch {
+                        continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Failed to add reminder: \(error.localizedDescription)"),
+                        ]))
+                    }
+                }
+            }
+        }
+
+        guard controller.presentedViewController == nil else {
+            continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Tool execution failed: authorization dialog is already presented."),
+            ]))
+            return
+        }
+
+        controller.present(alert, animated: true) {
+            guard alert.isVisible else {
+                continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Failed to display confirmation dialog."),
+                ]))
+                return
+            }
+        }
+    }
+}

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTCompleteReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTCompleteReminderTool.swift
@@ -96,11 +96,11 @@ class MTCompleteReminderTool: ModelTool, @unchecked Sendable {
             ReminderToolsShared.requestAccess { [weak self] granted in
                 Task { @MainActor in
                     guard let self else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.internalError("Reminder tool was deallocated before completion."))
                         return
                     }
                     guard granted else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.authorizationDeniedError())
                         return
                     }
 

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTCompleteReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTCompleteReminderTool.swift
@@ -1,0 +1,190 @@
+//
+//  MTCompleteReminderTool.swift
+//  FlowDown
+//
+//  Created by XZB-1248 on 5/10/26.
+//
+
+import AlertController
+import ChatClientKit
+import ConfigurableKit
+import EventKit
+import Foundation
+import UIKit
+
+class MTCompleteReminderTool: ModelTool, @unchecked Sendable {
+    override var shortDescription: String {
+        "mark a reminder as completed or uncompleted"
+    }
+
+    override var interfaceName: String {
+        String(localized: "Complete Reminder")
+    }
+
+    override var definition: ChatRequestBody.Tool {
+        .function(
+            name: "complete_reminder",
+            description: """
+            Mark a reminder as completed or un-complete it. Use query_reminders first to obtain the reminder_id.
+            """,
+            parameters: [
+                "type": "object",
+                "properties": [
+                    "reminder_id": [
+                        "type": "string",
+                        "description": "calendarItemIdentifier of the reminder, from query_reminders.",
+                    ],
+                    "completed": [
+                        "type": "boolean",
+                        "description": "true marks the reminder completed; false un-completes it.",
+                    ],
+                ],
+                "required": ["reminder_id", "completed"],
+                "additionalProperties": false,
+            ],
+            strict: true,
+        )
+    }
+
+    override class var controlObject: ConfigurableObject {
+        .init(
+            icon: "checklist",
+            title: "Complete Reminder",
+            explain: "Allows LLM to mark reminders as completed.",
+            key: "wiki.qaq.ModelTools.UpdateReminderTool.enabled",
+            defaultValue: true,
+            annotation: .toggle,
+        )
+    }
+
+    override func execute(with input: String, anchorTo view: UIView) async throws -> String {
+        guard let data = input.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let reminderId = json["reminder_id"] as? String, !reminderId.isEmpty
+        else {
+            throw NSError(
+                domain: "MTCompleteReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "reminder_id is required."),
+                ],
+            )
+        }
+
+        let completed = (json["completed"] as? Bool) ?? true
+
+        guard let viewController = await view.parentViewController else {
+            throw NSError(
+                domain: "MTCompleteReminderTool", code: 500, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Could not find view controller"),
+                ],
+            )
+        }
+
+        return try await completeWithUserInteraction(
+            reminderId: reminderId,
+            completed: completed,
+            controller: viewController,
+        )
+    }
+
+    @MainActor
+    private func completeWithUserInteraction(
+        reminderId: String,
+        completed: Bool,
+        controller: UIViewController,
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { cont in
+            ReminderToolsShared.requestAccess { [weak self] granted in
+                Task { @MainActor in
+                    guard let self else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+                    guard granted else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+
+                    let eventStore = EKEventStore()
+                    guard let reminder = ReminderToolsShared.fetchReminder(id: reminderId, eventStore: eventStore) else {
+                        cont.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Reminder with id \(reminderId) not found."),
+                        ]))
+                        return
+                    }
+
+                    self.showConfirmation(
+                        reminder: reminder,
+                        eventStore: eventStore,
+                        completed: completed,
+                        controller: controller,
+                        continuation: cont,
+                    )
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func showConfirmation(
+        reminder: EKReminder,
+        eventStore: EKEventStore,
+        completed: Bool,
+        controller: UIViewController,
+        continuation: CheckedContinuation<String, any Swift.Error>,
+    ) {
+        let title = reminder.title ?? String(localized: "Untitled")
+        let dialogTitle = completed
+            ? String(localized: "Mark as Done")
+            : String(localized: "Mark as Not Done")
+        let actionLabel = completed
+            ? String(localized: "Mark Done")
+            : String(localized: "Un-complete")
+
+        let alert = AlertViewController(
+            title: dialogTitle,
+            message: title,
+        ) { context in
+            context.addAction(title: "Cancel") {
+                context.dispose {
+                    continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                        NSLocalizedDescriptionKey: String(localized: "User cancelled the operation."),
+                    ]))
+                }
+            }
+            context.addAction(title: actionLabel, attribute: .accent) {
+                context.dispose {
+                    reminder.isCompleted = completed
+                    do {
+                        try eventStore.save(reminder, commit: true)
+                        let message: String = if completed {
+                            String(localized: "Reminder marked completed: \(title)")
+                        } else {
+                            String(localized: "Reminder marked uncompleted: \(title)")
+                        }
+                        continuation.resume(returning: message)
+                    } catch {
+                        continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Failed to update reminder: \(error.localizedDescription)"),
+                        ]))
+                    }
+                }
+            }
+        }
+
+        guard controller.presentedViewController == nil else {
+            continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Tool execution failed: authorization dialog is already presented."),
+            ]))
+            return
+        }
+
+        controller.present(alert, animated: true) {
+            guard alert.isVisible else {
+                continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Failed to display confirmation dialog."),
+                ]))
+                return
+            }
+        }
+    }
+}

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTDeleteReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTDeleteReminderTool.swift
@@ -1,0 +1,169 @@
+//
+//  MTDeleteReminderTool.swift
+//  FlowDown
+//
+//  Created by XZB-1248 on 5/10/26.
+//
+
+import AlertController
+import ChatClientKit
+import ConfigurableKit
+import EventKit
+import Foundation
+import UIKit
+
+class MTDeleteReminderTool: ModelTool, @unchecked Sendable {
+    override var shortDescription: String {
+        "delete a reminder by ID"
+    }
+
+    override var interfaceName: String {
+        String(localized: "Delete Reminder")
+    }
+
+    override var definition: ChatRequestBody.Tool {
+        .function(
+            name: "delete_reminder",
+            description: """
+            Permanently delete a reminder. Use query_reminders first to obtain the reminder_id. This is irreversible; the user is prompted before deletion.
+            """,
+            parameters: [
+                "type": "object",
+                "properties": [
+                    "reminder_id": [
+                        "type": "string",
+                        "description": "calendarItemIdentifier of the reminder to delete, from query_reminders.",
+                    ],
+                ],
+                "required": ["reminder_id"],
+                "additionalProperties": false,
+            ],
+            strict: true,
+        )
+    }
+
+    override class var controlObject: ConfigurableObject {
+        .init(
+            icon: "checklist",
+            title: "Delete Reminder",
+            explain: "Allows LLM to delete reminders. The user is asked to confirm each deletion.",
+            key: "wiki.qaq.ModelTools.DeleteReminderTool.enabled",
+            defaultValue: true,
+            annotation: .toggle,
+        )
+    }
+
+    override func execute(with input: String, anchorTo view: UIView) async throws -> String {
+        guard let data = input.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let reminderId = json["reminder_id"] as? String, !reminderId.isEmpty
+        else {
+            throw NSError(
+                domain: "MTDeleteReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "reminder_id is required."),
+                ],
+            )
+        }
+
+        guard let viewController = await view.parentViewController else {
+            throw NSError(
+                domain: "MTDeleteReminderTool", code: 500, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Could not find view controller"),
+                ],
+            )
+        }
+
+        return try await deleteWithUserInteraction(reminderId: reminderId, controller: viewController)
+    }
+
+    @MainActor
+    private func deleteWithUserInteraction(
+        reminderId: String,
+        controller: UIViewController,
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { cont in
+            ReminderToolsShared.requestAccess { [weak self] granted in
+                Task { @MainActor in
+                    guard let self else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+                    guard granted else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+
+                    let eventStore = EKEventStore()
+                    guard let reminder = ReminderToolsShared.fetchReminder(id: reminderId, eventStore: eventStore) else {
+                        cont.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Reminder with id \(reminderId) not found."),
+                        ]))
+                        return
+                    }
+
+                    self.showConfirmation(
+                        reminder: reminder,
+                        eventStore: eventStore,
+                        controller: controller,
+                        continuation: cont,
+                    )
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func showConfirmation(
+        reminder: EKReminder,
+        eventStore: EKEventStore,
+        controller: UIViewController,
+        continuation: CheckedContinuation<String, any Swift.Error>,
+    ) {
+        let title = reminder.title ?? String(localized: "Untitled")
+        let listName = reminder.calendar?.title ?? String(localized: "Reminders")
+
+        let body = title + "\n"
+            + String(localized: "List: \(listName)") + "\n\n"
+            + String(localized: "This cannot be undone.")
+        let alert = AlertViewController(
+            title: "Delete Reminder",
+            message: body,
+        ) { context in
+            context.addAction(title: "Cancel") {
+                context.dispose {
+                    continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                        NSLocalizedDescriptionKey: String(localized: "User cancelled the operation."),
+                    ]))
+                }
+            }
+            context.addAction(title: "Delete", attribute: .accent) {
+                context.dispose {
+                    do {
+                        try eventStore.remove(reminder, commit: true)
+                        continuation.resume(returning: String(localized: "Reminder deleted: \(title)"))
+                    } catch {
+                        continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Failed to delete reminder: \(error.localizedDescription)"),
+                        ]))
+                    }
+                }
+            }
+        }
+
+        guard controller.presentedViewController == nil else {
+            continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Tool execution failed: authorization dialog is already presented."),
+            ]))
+            return
+        }
+
+        controller.present(alert, animated: true) {
+            guard alert.isVisible else {
+                continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Failed to display confirmation dialog."),
+                ]))
+                return
+            }
+        }
+    }
+}

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTDeleteReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTDeleteReminderTool.swift
@@ -85,11 +85,11 @@ class MTDeleteReminderTool: ModelTool, @unchecked Sendable {
             ReminderToolsShared.requestAccess { [weak self] granted in
                 Task { @MainActor in
                     guard let self else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.internalError("Reminder tool was deallocated before completion."))
                         return
                     }
                     guard granted else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.authorizationDeniedError())
                         return
                     }
 

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTQueryReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTQueryReminderTool.swift
@@ -137,7 +137,7 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
         )
     }
 
-    private struct DateRange {
+    struct DateRange: Equatable {
         let start: Date?
         let end: Date?
 
@@ -150,7 +150,7 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
         }
     }
 
-    private static func parseRange(
+    static func parseRange(
         prefix: String,
         startString: String,
         endString: String,
@@ -199,17 +199,34 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
             ReminderToolsShared.requestAccess { [weak self] granted in
                 Task { @MainActor in
                     guard let self else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.internalError("Reminder tool was deallocated before completion."))
                         return
                     }
                     guard granted else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.authorizationDeniedError())
                         return
                     }
 
+                    let eventStore = EKEventStore()
+                    let calendars: [EKCalendar]?
+                    if listName.isEmpty {
+                        calendars = nil
+                    } else {
+                        do {
+                            calendars = [try ReminderToolsShared.resolveCalendarRequiringName(
+                                named: listName,
+                                eventStore: eventStore,
+                            )]
+                        } catch {
+                            cont.resume(throwing: error)
+                            return
+                        }
+                    }
+
                     self.fetchReminders(
+                        eventStore: eventStore,
+                        calendars: calendars,
                         status: status,
-                        listName: listName,
                         due: due,
                         alert: alert,
                         completed: completed,
@@ -230,30 +247,14 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
     }
 
     private func fetchReminders(
+        eventStore: EKEventStore,
+        calendars: [EKCalendar]?,
         status: String,
-        listName: String,
         due: DateRange,
         alert: DateRange,
         completed: DateRange,
         completion: @escaping (String) -> Void,
     ) {
-        let eventStore = EKEventStore()
-
-        let calendars: [EKCalendar]?
-        if !listName.isEmpty {
-            let trimmed = listName.trimmingCharacters(in: .whitespacesAndNewlines)
-            let match = eventStore.calendars(for: .reminder)
-                .first { $0.title.caseInsensitiveCompare(trimmed) == .orderedSame }
-            if let match {
-                calendars = [match]
-            } else {
-                completion(String(localized: "No Reminders list named \"\(listName)\" found."))
-                return
-            }
-        } else {
-            calendars = nil
-        }
-
         // EventKit's status-specific predicates can take a date range, but they
         // bind it to a specific field (due date for incomplete, completion date
         // for completed). The tool exposes three independent ranges that are
@@ -289,7 +290,7 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
         }
     }
 
-    private static func applyDateFilters(
+    static func applyDateFilters(
         _ reminders: [EKReminder],
         due: DateRange,
         alert: DateRange,

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTQueryReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTQueryReminderTool.swift
@@ -1,0 +1,303 @@
+//
+//  MTQueryReminderTool.swift
+//  FlowDown
+//
+//  Created by XZB-1248 on 5/10/26.
+//
+
+import AlertController
+import ChatClientKit
+import ConfigurableKit
+import EventKit
+import Foundation
+import UIKit
+
+class MTQueryReminderTool: ModelTool, @unchecked Sendable {
+    override var shortDescription: String {
+        "query reminders from user's system Reminders"
+    }
+
+    override var interfaceName: String {
+        String(localized: "Query Reminders")
+    }
+
+    override var definition: ChatRequestBody.Tool {
+        .function(
+            name: "query_reminders",
+            description: """
+            Query reminders from the user's system Reminders. Filter by completion status and optionally by due-date range and Reminders list name. Reminders without a due date are included regardless of date range.
+            Date range cannot exceed 365 days. All dates are ISO 8601 UTC.
+            Pass empty strings for any optional filter you don't want applied.
+            """,
+            parameters: [
+                "type": "object",
+                "properties": [
+                    "status": [
+                        "type": "string",
+                        "enum": ["incomplete", "completed", "all"],
+                        "description": "Which reminders to return.",
+                    ],
+                    "start_date": [
+                        "type": "string",
+                        "description": "Lower bound of due-date filter in ISO 8601 UTC. Pass empty string to skip the lower bound.",
+                    ],
+                    "end_date": [
+                        "type": "string",
+                        "description": "Upper bound of due-date filter in ISO 8601 UTC. Pass empty string to skip the upper bound.",
+                    ],
+                    "list_name": [
+                        "type": "string",
+                        "description": "Restrict to a single Reminders list by name. Pass empty string to query all lists.",
+                    ],
+                ],
+                "required": ["status", "start_date", "end_date", "list_name"],
+                "additionalProperties": false,
+            ],
+            strict: true,
+        )
+    }
+
+    override class var controlObject: ConfigurableObject {
+        .init(
+            icon: "checklist",
+            title: "Query Reminders",
+            explain: "Allows LLM to read your reminders.",
+            key: "wiki.qaq.ModelTools.QueryReminderTool.enabled",
+            defaultValue: true,
+            annotation: .toggle,
+        )
+    }
+
+    override func execute(with input: String, anchorTo view: UIView) async throws -> String {
+        guard let data = input.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw NSError(
+                domain: "MTQueryReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Invalid input parameters"),
+                ],
+            )
+        }
+
+        let status = (json["status"] as? String) ?? "incomplete"
+        let startDateString = (json["start_date"] as? String) ?? ""
+        let endDateString = (json["end_date"] as? String) ?? ""
+        let listName = (json["list_name"] as? String) ?? ""
+
+        let startDate = startDateString.isEmpty ? nil : ReminderToolsShared.parseISODate(startDateString)
+        let endDate = endDateString.isEmpty ? nil : ReminderToolsShared.parseISODate(endDateString)
+
+        if !startDateString.isEmpty, startDate == nil {
+            throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Invalid start_date format. Use ISO 8601 UTC."),
+            ])
+        }
+        if !endDateString.isEmpty, endDate == nil {
+            throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Invalid end_date format. Use ISO 8601 UTC."),
+            ])
+        }
+
+        if let startDate, let endDate {
+            let days = Calendar.current.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+            if days > 365 {
+                throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Date range cannot exceed 365 days"),
+                ])
+            }
+        }
+
+        guard let viewController = await view.parentViewController else {
+            throw NSError(domain: "MTQueryReminderTool", code: 500, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Could not find view controller"),
+            ])
+        }
+
+        return try await queryWithUserInteraction(
+            status: status,
+            startDate: startDate,
+            endDate: endDate,
+            listName: listName,
+            controller: viewController,
+        )
+    }
+
+    @MainActor
+    private func queryWithUserInteraction(
+        status: String,
+        startDate: Date?,
+        endDate: Date?,
+        listName: String,
+        controller: UIViewController,
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { cont in
+            ReminderToolsShared.requestAccess { [weak self] granted in
+                Task { @MainActor in
+                    guard let self else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+                    guard granted else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+
+                    self.fetchReminders(
+                        status: status,
+                        startDate: startDate,
+                        endDate: endDate,
+                        listName: listName,
+                    ) { result in
+                        // EventKit's fetchReminders callback fires on a background
+                        // queue; hop back to the main actor before touching UI.
+                        Task { @MainActor [weak self] in
+                            guard let self else {
+                                cont.resume(returning: result)
+                                return
+                            }
+                            self.showResults(result: result, controller: controller, continuation: cont)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func fetchReminders(
+        status: String,
+        startDate: Date?,
+        endDate: Date?,
+        listName: String,
+        completion: @escaping (String) -> Void,
+    ) {
+        let eventStore = EKEventStore()
+
+        let calendars: [EKCalendar]?
+        if !listName.isEmpty {
+            let trimmed = listName.trimmingCharacters(in: .whitespacesAndNewlines)
+            let match = eventStore.calendars(for: .reminder)
+                .first { $0.title.caseInsensitiveCompare(trimmed) == .orderedSame }
+            if let match {
+                calendars = [match]
+            } else {
+                completion(String(localized: "No Reminders list named \"\(listName)\" found."))
+                return
+            }
+        } else {
+            calendars = nil
+        }
+
+        let predicate: NSPredicate
+        switch status {
+        case "completed":
+            predicate = eventStore.predicateForCompletedReminders(
+                withCompletionDateStarting: startDate,
+                ending: endDate,
+                calendars: calendars,
+            )
+        case "all":
+            predicate = eventStore.predicateForReminders(in: calendars)
+        default:
+            predicate = eventStore.predicateForIncompleteReminders(
+                withDueDateStarting: startDate,
+                ending: endDate,
+                calendars: calendars,
+            )
+        }
+
+        eventStore.fetchReminders(matching: predicate) { reminders in
+            let list = reminders ?? []
+            let filtered: [EKReminder]
+            if status == "all", let startDate, let endDate {
+                filtered = list.filter { reminder in
+                    guard let components = reminder.dueDateComponents,
+                          let date = Calendar.current.date(from: components)
+                    else { return true }
+                    return date >= startDate && date <= endDate
+                }
+            } else {
+                filtered = list
+            }
+            completion(ReminderToolsShared.formatReminders(filtered))
+        }
+    }
+
+    @MainActor
+    private func showResults(
+        result: String,
+        controller: UIViewController,
+        continuation: CheckedContinuation<String, any Swift.Error>,
+    ) {
+        let preview = formatPreview(result)
+
+        let alert = AlertViewController(
+            title: "Reminders",
+            message: preview,
+        ) { context in
+            context.addAction(title: "Cancel") {
+                context.dispose {
+                    continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                        NSLocalizedDescriptionKey: String(localized: "User cancelled sharing reminders."),
+                    ]))
+                }
+            }
+            context.addAction(title: "Share", attribute: .accent) {
+                context.dispose {
+                    continuation.resume(returning: result)
+                }
+            }
+        }
+
+        guard controller.presentedViewController == nil else {
+            continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Tool execution failed: authorization dialog is already presented."),
+            ]))
+            return
+        }
+
+        controller.present(alert, animated: true) {
+            guard alert.isVisible else {
+                continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Failed to display results dialog."),
+                ]))
+                return
+            }
+        }
+    }
+
+    private func formatPreview(_ markdown: String) -> String {
+        var displayLines: [String] = []
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false)
+
+        var lineCount = 0
+        var truncated = false
+        for line in lines {
+            lineCount += 1
+            if lineCount > 8 {
+                truncated = true
+                break
+            }
+
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("# ") {
+                let title = String(trimmed.dropFirst(2))
+                displayLines.append(title)
+                displayLines.append(String(repeating: "-", count: title.count))
+            } else if trimmed.hasPrefix("- ") {
+                var line = String(trimmed.dropFirst(2))
+                if let idRange = line.range(of: " [id: ") {
+                    line = String(line[..<idRange.lowerBound])
+                }
+                displayLines.append("• " + line)
+            } else if !trimmed.isEmpty {
+                displayLines.append(trimmed)
+            }
+        }
+
+        if truncated {
+            displayLines.append("\n... \(String(localized: "More reminders available"))")
+        }
+
+        return displayLines.joined(separator: "\n")
+    }
+}

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTQueryReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTQueryReminderTool.swift
@@ -25,9 +25,11 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
         .function(
             name: "query_reminders",
             description: """
-            Query reminders from the user's system Reminders. Filter by completion status and optionally by due-date range and Reminders list name. Reminders without a due date are included regardless of date range.
-            Date range cannot exceed 365 days. All dates are ISO 8601 UTC.
-            Pass empty strings for any optional filter you don't want applied.
+            Query reminders from the user's system Reminders. Filter by completion status, by Reminders list name, and optionally by independent date ranges on the reminder's due date, alarm/alert time, and completion date.
+            Each range is applied independently with AND semantics: a reminder is returned only when every *active* range matches (a range is active when at least one of its bounds is non-empty). Reminders missing the field that an active range targets are excluded by that range (e.g. an incomplete reminder is excluded by any active completed_* range; a reminder with no alarms is excluded by any active alert_* range).
+            The alert range matches when *any* alarm on the reminder has an absolute date inside the range. The completed range is only meaningful for completed reminders.
+            Each individual range cannot exceed 365 days, and start must be on or before end. All dates are ISO 8601 UTC.
+            Pass empty strings for any range you don't want to apply.
             """,
             parameters: [
                 "type": "object",
@@ -37,20 +39,41 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
                         "enum": ["incomplete", "completed", "all"],
                         "description": "Which reminders to return.",
                     ],
-                    "start_date": [
-                        "type": "string",
-                        "description": "Lower bound of due-date filter in ISO 8601 UTC. Pass empty string to skip the lower bound.",
-                    ],
-                    "end_date": [
-                        "type": "string",
-                        "description": "Upper bound of due-date filter in ISO 8601 UTC. Pass empty string to skip the upper bound.",
-                    ],
                     "list_name": [
                         "type": "string",
                         "description": "Restrict to a single Reminders list by name. Pass empty string to query all lists.",
                     ],
+                    "due_start_date": [
+                        "type": "string",
+                        "description": "Lower bound for the reminder's due date, ISO 8601 UTC. Pass empty string to skip.",
+                    ],
+                    "due_end_date": [
+                        "type": "string",
+                        "description": "Upper bound for the reminder's due date, ISO 8601 UTC. Pass empty string to skip.",
+                    ],
+                    "alert_start_date": [
+                        "type": "string",
+                        "description": "Lower bound for any alarm/alert time on the reminder, ISO 8601 UTC. Pass empty string to skip.",
+                    ],
+                    "alert_end_date": [
+                        "type": "string",
+                        "description": "Upper bound for any alarm/alert time on the reminder, ISO 8601 UTC. Pass empty string to skip.",
+                    ],
+                    "completed_start_date": [
+                        "type": "string",
+                        "description": "Lower bound for the reminder's completion date, ISO 8601 UTC. Pass empty string to skip.",
+                    ],
+                    "completed_end_date": [
+                        "type": "string",
+                        "description": "Upper bound for the reminder's completion date, ISO 8601 UTC. Pass empty string to skip.",
+                    ],
                 ],
-                "required": ["status", "start_date", "end_date", "list_name"],
+                "required": [
+                    "status", "list_name",
+                    "due_start_date", "due_end_date",
+                    "alert_start_date", "alert_end_date",
+                    "completed_start_date", "completed_end_date",
+                ],
                 "additionalProperties": false,
             ],
             strict: true,
@@ -80,32 +103,23 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
         }
 
         let status = (json["status"] as? String) ?? "incomplete"
-        let startDateString = (json["start_date"] as? String) ?? ""
-        let endDateString = (json["end_date"] as? String) ?? ""
         let listName = (json["list_name"] as? String) ?? ""
 
-        let startDate = startDateString.isEmpty ? nil : ReminderToolsShared.parseISODate(startDateString)
-        let endDate = endDateString.isEmpty ? nil : ReminderToolsShared.parseISODate(endDateString)
-
-        if !startDateString.isEmpty, startDate == nil {
-            throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
-                NSLocalizedDescriptionKey: String(localized: "Invalid start_date format. Use ISO 8601 UTC."),
-            ])
-        }
-        if !endDateString.isEmpty, endDate == nil {
-            throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
-                NSLocalizedDescriptionKey: String(localized: "Invalid end_date format. Use ISO 8601 UTC."),
-            ])
-        }
-
-        if let startDate, let endDate {
-            let days = Calendar.current.dateComponents([.day], from: startDate, to: endDate).day ?? 0
-            if days > 365 {
-                throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
-                    NSLocalizedDescriptionKey: String(localized: "Date range cannot exceed 365 days"),
-                ])
-            }
-        }
+        let dueRange = try Self.parseRange(
+            prefix: "due",
+            startString: (json["due_start_date"] as? String) ?? "",
+            endString: (json["due_end_date"] as? String) ?? "",
+        )
+        let alertRange = try Self.parseRange(
+            prefix: "alert",
+            startString: (json["alert_start_date"] as? String) ?? "",
+            endString: (json["alert_end_date"] as? String) ?? "",
+        )
+        let completedRange = try Self.parseRange(
+            prefix: "completed",
+            startString: (json["completed_start_date"] as? String) ?? "",
+            endString: (json["completed_end_date"] as? String) ?? "",
+        )
 
         guard let viewController = await view.parentViewController else {
             throw NSError(domain: "MTQueryReminderTool", code: 500, userInfo: [
@@ -115,19 +129,70 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
 
         return try await queryWithUserInteraction(
             status: status,
-            startDate: startDate,
-            endDate: endDate,
             listName: listName,
+            due: dueRange,
+            alert: alertRange,
+            completed: completedRange,
             controller: viewController,
         )
+    }
+
+    private struct DateRange {
+        let start: Date?
+        let end: Date?
+
+        var isActive: Bool { start != nil || end != nil }
+
+        func contains(_ date: Date) -> Bool {
+            if let start, date < start { return false }
+            if let end, date > end { return false }
+            return true
+        }
+    }
+
+    private static func parseRange(
+        prefix: String,
+        startString: String,
+        endString: String,
+    ) throws -> DateRange {
+        let start = startString.isEmpty ? nil : ReminderToolsShared.parseISODate(startString)
+        let end = endString.isEmpty ? nil : ReminderToolsShared.parseISODate(endString)
+
+        if !startString.isEmpty, start == nil {
+            throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
+                NSLocalizedDescriptionKey: "\(prefix): " + String(localized: "Invalid start_date format. Use ISO 8601 UTC."),
+            ])
+        }
+        if !endString.isEmpty, end == nil {
+            throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
+                NSLocalizedDescriptionKey: "\(prefix): " + String(localized: "Invalid end_date format. Use ISO 8601 UTC."),
+            ])
+        }
+
+        if let start, let end {
+            if end < start {
+                throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: "\(prefix): " + String(localized: "start_date must be on or before end_date."),
+                ])
+            }
+            let days = Calendar.current.dateComponents([.day], from: start, to: end).day ?? 0
+            if days > 365 {
+                throw NSError(domain: "MTQueryReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: "\(prefix): " + String(localized: "Date range cannot exceed 365 days"),
+                ])
+            }
+        }
+
+        return DateRange(start: start, end: end)
     }
 
     @MainActor
     private func queryWithUserInteraction(
         status: String,
-        startDate: Date?,
-        endDate: Date?,
         listName: String,
+        due: DateRange,
+        alert: DateRange,
+        completed: DateRange,
         controller: UIViewController,
     ) async throws -> String {
         try await withCheckedThrowingContinuation { cont in
@@ -144,9 +209,10 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
 
                     self.fetchReminders(
                         status: status,
-                        startDate: startDate,
-                        endDate: endDate,
                         listName: listName,
+                        due: due,
+                        alert: alert,
+                        completed: completed,
                     ) { result in
                         // EventKit's fetchReminders callback fires on a background
                         // queue; hop back to the main actor before touching UI.
@@ -165,9 +231,10 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
 
     private func fetchReminders(
         status: String,
-        startDate: Date?,
-        endDate: Date?,
         listName: String,
+        due: DateRange,
+        alert: DateRange,
+        completed: DateRange,
         completion: @escaping (String) -> Void,
     ) {
         let eventStore = EKEventStore()
@@ -187,38 +254,66 @@ class MTQueryReminderTool: ModelTool, @unchecked Sendable {
             calendars = nil
         }
 
+        // EventKit's status-specific predicates can take a date range, but they
+        // bind it to a specific field (due date for incomplete, completion date
+        // for completed). The tool exposes three independent ranges that are
+        // ANDed together, so we always fetch the full status set and apply the
+        // ranges in Swift below.
         let predicate: NSPredicate
         switch status {
         case "completed":
             predicate = eventStore.predicateForCompletedReminders(
-                withCompletionDateStarting: startDate,
-                ending: endDate,
+                withCompletionDateStarting: nil,
+                ending: nil,
                 calendars: calendars,
             )
         case "all":
             predicate = eventStore.predicateForReminders(in: calendars)
         default:
             predicate = eventStore.predicateForIncompleteReminders(
-                withDueDateStarting: startDate,
-                ending: endDate,
+                withDueDateStarting: nil,
+                ending: nil,
                 calendars: calendars,
             )
         }
 
         eventStore.fetchReminders(matching: predicate) { reminders in
             let list = reminders ?? []
-            let filtered: [EKReminder]
-            if status == "all", let startDate, let endDate {
-                filtered = list.filter { reminder in
-                    guard let components = reminder.dueDateComponents,
-                          let date = Calendar.current.date(from: components)
-                    else { return true }
-                    return date >= startDate && date <= endDate
-                }
-            } else {
-                filtered = list
-            }
+            let filtered = Self.applyDateFilters(
+                list,
+                due: due,
+                alert: alert,
+                completed: completed,
+            )
             completion(ReminderToolsShared.formatReminders(filtered))
+        }
+    }
+
+    private static func applyDateFilters(
+        _ reminders: [EKReminder],
+        due: DateRange,
+        alert: DateRange,
+        completed: DateRange,
+    ) -> [EKReminder] {
+        if !due.isActive, !alert.isActive, !completed.isActive {
+            return reminders
+        }
+
+        return reminders.filter { reminder in
+            if due.isActive {
+                guard let components = reminder.dueDateComponents,
+                      let date = Calendar.current.date(from: components),
+                      due.contains(date)
+                else { return false }
+            }
+            if alert.isActive {
+                let alarmDates = (reminder.alarms ?? []).compactMap(\.absoluteDate)
+                guard alarmDates.contains(where: alert.contains) else { return false }
+            }
+            if completed.isActive {
+                guard let date = reminder.completionDate, completed.contains(date) else { return false }
+            }
+            return true
         }
     }
 

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTUpdateReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTUpdateReminderTool.swift
@@ -1,0 +1,264 @@
+//
+//  MTUpdateReminderTool.swift
+//  FlowDown
+//
+//  Created by XZB-1248 on 5/10/26.
+//
+
+import AlertController
+import ChatClientKit
+import ConfigurableKit
+import EventKit
+import Foundation
+import UIKit
+
+class MTUpdateReminderTool: ModelTool, @unchecked Sendable {
+    override var shortDescription: String {
+        "update fields of an existing reminder by ID"
+    }
+
+    override var interfaceName: String {
+        String(localized: "Update Reminder")
+    }
+
+    override var definition: ChatRequestBody.Tool {
+        .function(
+            name: "update_reminder",
+            description: """
+            Update an existing reminder. Use query_reminders first to obtain the reminder_id. Pass empty string (or -1 for priority) to leave a field unchanged. All dates are ISO 8601 UTC.
+            """,
+            parameters: [
+                "type": "object",
+                "properties": [
+                    "reminder_id": [
+                        "type": "string",
+                        "description": "calendarItemIdentifier of the reminder, from query_reminders.",
+                    ],
+                    "title": [
+                        "type": "string",
+                        "description": "New title. Pass empty string to leave unchanged.",
+                    ],
+                    "notes": [
+                        "type": "string",
+                        "description": "New notes. Pass empty string to leave unchanged.",
+                    ],
+                    "due_date": [
+                        "type": "string",
+                        "description": "New due date in ISO 8601 UTC (yyyy-MM-dd'T'HH:mm:ss'Z'). Pass empty string to leave unchanged.",
+                    ],
+                    "priority": [
+                        "type": "integer",
+                        "description": "New priority (0 = none, 1 = high, 5 = medium, 9 = low). Pass -1 to leave unchanged.",
+                    ],
+                    "list_name": [
+                        "type": "string",
+                        "description": "Move to this Reminders list by name. Pass empty string to leave unchanged.",
+                    ],
+                ],
+                "required": ["reminder_id", "title", "notes", "due_date", "priority", "list_name"],
+                "additionalProperties": false,
+            ],
+            strict: true,
+        )
+    }
+
+    override class var controlObject: ConfigurableObject {
+        .init(
+            icon: "checklist",
+            title: "Update Reminder",
+            explain: "Allows LLM to modify reminders, including marking them as complete.",
+            key: "wiki.qaq.ModelTools.UpdateReminderTool.enabled",
+            defaultValue: true,
+            annotation: .toggle,
+        )
+    }
+
+    override func execute(with input: String, anchorTo view: UIView) async throws -> String {
+        guard let data = input.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let reminderId = json["reminder_id"] as? String, !reminderId.isEmpty
+        else {
+            throw NSError(
+                domain: "MTUpdateReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "reminder_id is required."),
+                ],
+            )
+        }
+
+        // Empty strings (and priority < 0) mean "leave unchanged" — strict mode
+        // requires every property in `required`, so the LLM has to provide all
+        // of them on every call.
+        let titleChange = (json["title"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let notesChange = (json["notes"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let dueDateChange = (json["due_date"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let priorityRaw = (json["priority"] as? Int).flatMap { $0 < 0 ? nil : $0 }
+        let listNameChange = (json["list_name"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+
+        if let dueDateChange, ReminderToolsShared.parseISODate(dueDateChange) == nil {
+            throw NSError(
+                domain: "MTUpdateReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Invalid due_date format. Use ISO 8601 UTC."),
+                ],
+            )
+        }
+
+        guard let viewController = await view.parentViewController else {
+            throw NSError(
+                domain: "MTUpdateReminderTool", code: 500, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Could not find view controller"),
+                ],
+            )
+        }
+
+        return try await updateWithUserInteraction(
+            reminderId: reminderId,
+            newTitle: titleChange,
+            newNotes: notesChange,
+            newDueDate: dueDateChange,
+            newPriority: priorityRaw,
+            newListName: listNameChange,
+            controller: viewController,
+        )
+    }
+
+    @MainActor
+    private func updateWithUserInteraction(
+        reminderId: String,
+        newTitle: String?,
+        newNotes: String?,
+        newDueDate: String?,
+        newPriority: Int?,
+        newListName: String?,
+        controller: UIViewController,
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { cont in
+            ReminderToolsShared.requestAccess { [weak self] granted in
+                Task { @MainActor in
+                    guard let self else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+                    guard granted else {
+                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        return
+                    }
+
+                    let eventStore = EKEventStore()
+                    guard let reminder = ReminderToolsShared.fetchReminder(id: reminderId, eventStore: eventStore) else {
+                        cont.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Reminder with id \(reminderId) not found."),
+                        ]))
+                        return
+                    }
+
+                    self.showConfirmation(
+                        reminder: reminder,
+                        eventStore: eventStore,
+                        newTitle: newTitle,
+                        newNotes: newNotes,
+                        newDueDate: newDueDate,
+                        newPriority: newPriority,
+                        newListName: newListName,
+                        controller: controller,
+                        continuation: cont,
+                    )
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func showConfirmation(
+        reminder: EKReminder,
+        eventStore: EKEventStore,
+        newTitle: String?,
+        newNotes: String?,
+        newDueDate: String?,
+        newPriority: Int?,
+        newListName: String?,
+        controller: UIViewController,
+        continuation: CheckedContinuation<String, any Swift.Error>,
+    ) {
+        var changes: [String] = []
+        if let newTitle {
+            changes.append(String(localized: "Title: \(reminder.title ?? "-") → \(newTitle)"))
+        }
+        if let newNotes {
+            changes.append(String(localized: "Notes → \(newNotes)"))
+        }
+        if let newDueDate {
+            changes.append(String(localized: "Due → \(newDueDate)"))
+        }
+        if let newPriority {
+            changes.append(String(localized: "Priority → \(ReminderToolsShared.priorityLabel(newPriority))"))
+        }
+        if let newListName {
+            changes.append(String(localized: "List → \(newListName)"))
+        }
+
+        if changes.isEmpty {
+            continuation.resume(returning: String(localized: "No changes specified; reminder left untouched."))
+            return
+        }
+
+        let title = reminder.title ?? String(localized: "Untitled")
+        let body = title + "\n\n" + changes.joined(separator: "\n")
+        let alert = AlertViewController(
+            title: "Update Reminder",
+            message: body,
+        ) { context in
+            context.addAction(title: "Cancel") {
+                context.dispose {
+                    continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                        NSLocalizedDescriptionKey: String(localized: "User cancelled the operation."),
+                    ]))
+                }
+            }
+            context.addAction(title: "Update", attribute: .accent) {
+                context.dispose {
+                    if let newTitle { reminder.title = newTitle }
+                    if let newNotes { reminder.notes = newNotes }
+                    if let newDueDate, let date = ReminderToolsShared.parseISODate(newDueDate) {
+                        reminder.dueDateComponents = Calendar.current.dateComponents(
+                            [.year, .month, .day, .hour, .minute],
+                            from: date,
+                        )
+                    }
+                    if let newPriority {
+                        reminder.priority = newPriority
+                    }
+                    if let newListName,
+                       let calendar = ReminderToolsShared.resolveCalendar(named: newListName, eventStore: eventStore)
+                    {
+                        reminder.calendar = calendar
+                    }
+
+                    do {
+                        try eventStore.save(reminder, commit: true)
+                        continuation.resume(returning: String(localized: "Reminder updated: \(reminder.title ?? "-")"))
+                    } catch {
+                        continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                            NSLocalizedDescriptionKey: String(localized: "Failed to update reminder: \(error.localizedDescription)"),
+                        ]))
+                    }
+                }
+            }
+        }
+
+        guard controller.presentedViewController == nil else {
+            continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Tool execution failed: authorization dialog is already presented."),
+            ]))
+            return
+        }
+
+        controller.present(alert, animated: true) {
+            guard alert.isVisible else {
+                continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Failed to display confirmation dialog."),
+                ]))
+                return
+            }
+        }
+    }
+}

--- a/FlowDown/Backend/ModelTools/ReminderTools/MTUpdateReminderTool.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/MTUpdateReminderTool.swift
@@ -25,7 +25,7 @@ class MTUpdateReminderTool: ModelTool, @unchecked Sendable {
         .function(
             name: "update_reminder",
             description: """
-            Update an existing reminder. Use query_reminders first to obtain the reminder_id. Pass empty string (or -1 for priority) to leave a field unchanged. All dates are ISO 8601 UTC.
+            Update an existing reminder. Use query_reminders first to obtain the reminder_id. To leave a field unchanged, pass empty string (or -1 for priority) and false for the matching clear_* flag. To clear a field back to empty, set the matching clear_* flag to true and pass empty string (or -1 for priority) for the value. Sending both a non-empty value and clear_*=true on the same field is rejected. list_name has no clear flag because every reminder must live in some list. All dates are ISO 8601 UTC.
             """,
             parameters: [
                 "type": "object",
@@ -42,20 +42,39 @@ class MTUpdateReminderTool: ModelTool, @unchecked Sendable {
                         "type": "string",
                         "description": "New notes. Pass empty string to leave unchanged.",
                     ],
+                    "clear_notes": [
+                        "type": "boolean",
+                        "description": "Set true to remove existing notes. Cannot be combined with a non-empty notes value.",
+                    ],
                     "due_date": [
                         "type": "string",
                         "description": "New due date in ISO 8601 UTC (yyyy-MM-dd'T'HH:mm:ss'Z'). Pass empty string to leave unchanged.",
+                    ],
+                    "clear_due_date": [
+                        "type": "boolean",
+                        "description": "Set true to remove the existing due date. Cannot be combined with a non-empty due_date.",
                     ],
                     "priority": [
                         "type": "integer",
                         "description": "New priority (0 = none, 1 = high, 5 = medium, 9 = low). Pass -1 to leave unchanged.",
                     ],
+                    "clear_priority": [
+                        "type": "boolean",
+                        "description": "Set true to clear priority back to none (0). Cannot be combined with a priority >= 0.",
+                    ],
                     "list_name": [
                         "type": "string",
-                        "description": "Move to this Reminders list by name. Pass empty string to leave unchanged.",
+                        "description": "Move to this Reminders list by name. Pass empty string to leave unchanged. The list must already exist.",
                     ],
                 ],
-                "required": ["reminder_id", "title", "notes", "due_date", "priority", "list_name"],
+                "required": [
+                    "reminder_id",
+                    "title",
+                    "notes", "clear_notes",
+                    "due_date", "clear_due_date",
+                    "priority", "clear_priority",
+                    "list_name",
+                ],
                 "additionalProperties": false,
             ],
             strict: true,
@@ -85,22 +104,7 @@ class MTUpdateReminderTool: ModelTool, @unchecked Sendable {
             )
         }
 
-        // Empty strings (and priority < 0) mean "leave unchanged" — strict mode
-        // requires every property in `required`, so the LLM has to provide all
-        // of them on every call.
-        let titleChange = (json["title"] as? String).flatMap { $0.isEmpty ? nil : $0 }
-        let notesChange = (json["notes"] as? String).flatMap { $0.isEmpty ? nil : $0 }
-        let dueDateChange = (json["due_date"] as? String).flatMap { $0.isEmpty ? nil : $0 }
-        let priorityRaw = (json["priority"] as? Int).flatMap { $0 < 0 ? nil : $0 }
-        let listNameChange = (json["list_name"] as? String).flatMap { $0.isEmpty ? nil : $0 }
-
-        if let dueDateChange, ReminderToolsShared.parseISODate(dueDateChange) == nil {
-            throw NSError(
-                domain: "MTUpdateReminderTool", code: 400, userInfo: [
-                    NSLocalizedDescriptionKey: String(localized: "Invalid due_date format. Use ISO 8601 UTC."),
-                ],
-            )
-        }
+        let parsed = try Self.parseChanges(from: json)
 
         guard let viewController = await view.parentViewController else {
             throw NSError(
@@ -112,34 +116,102 @@ class MTUpdateReminderTool: ModelTool, @unchecked Sendable {
 
         return try await updateWithUserInteraction(
             reminderId: reminderId,
+            changes: parsed,
+            controller: viewController,
+        )
+    }
+
+    struct ParsedChanges: Equatable {
+        var newTitle: String?
+        var newNotes: String?
+        var clearNotes: Bool
+        var newDueDate: String?
+        var clearDueDate: Bool
+        var newPriority: Int?
+        var clearPriority: Bool
+        var newListName: String?
+
+        var isEmpty: Bool {
+            newTitle == nil
+                && newNotes == nil && !clearNotes
+                && newDueDate == nil && !clearDueDate
+                && newPriority == nil && !clearPriority
+                && newListName == nil
+        }
+    }
+
+    static func parseChanges(from json: [String: Any]) throws -> ParsedChanges {
+        // Empty strings (and priority < 0) mean "leave unchanged" — strict mode
+        // requires every property in `required`, so the LLM has to provide all
+        // of them on every call. The boolean clear_* siblings are the explicit
+        // "set this back to empty" signal.
+        let titleChange = (json["title"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let notesChange = (json["notes"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let dueDateChange = (json["due_date"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let priorityRaw = (json["priority"] as? Int).flatMap { $0 < 0 ? nil : $0 }
+        let listNameChange = (json["list_name"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+
+        let clearNotes = (json["clear_notes"] as? Bool) ?? false
+        let clearDueDate = (json["clear_due_date"] as? Bool) ?? false
+        let clearPriority = (json["clear_priority"] as? Bool) ?? false
+
+        if clearNotes, notesChange != nil {
+            throw NSError(
+                domain: "MTUpdateReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "clear_notes cannot be combined with a non-empty notes value."),
+                ],
+            )
+        }
+        if clearDueDate, dueDateChange != nil {
+            throw NSError(
+                domain: "MTUpdateReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "clear_due_date cannot be combined with a non-empty due_date value."),
+                ],
+            )
+        }
+        if clearPriority, priorityRaw != nil {
+            throw NSError(
+                domain: "MTUpdateReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "clear_priority cannot be combined with a priority >= 0."),
+                ],
+            )
+        }
+
+        if let dueDateChange, ReminderToolsShared.parseISODate(dueDateChange) == nil {
+            throw NSError(
+                domain: "MTUpdateReminderTool", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: String(localized: "Invalid due_date format. Use ISO 8601 UTC."),
+                ],
+            )
+        }
+
+        return ParsedChanges(
             newTitle: titleChange,
             newNotes: notesChange,
+            clearNotes: clearNotes,
             newDueDate: dueDateChange,
+            clearDueDate: clearDueDate,
             newPriority: priorityRaw,
+            clearPriority: clearPriority,
             newListName: listNameChange,
-            controller: viewController,
         )
     }
 
     @MainActor
     private func updateWithUserInteraction(
         reminderId: String,
-        newTitle: String?,
-        newNotes: String?,
-        newDueDate: String?,
-        newPriority: Int?,
-        newListName: String?,
+        changes: ParsedChanges,
         controller: UIViewController,
     ) async throws -> String {
         try await withCheckedThrowingContinuation { cont in
             ReminderToolsShared.requestAccess { [weak self] granted in
                 Task { @MainActor in
                     guard let self else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.internalError("Reminder tool was deallocated before completion."))
                         return
                     }
                     guard granted else {
-                        cont.resume(returning: String(localized: "Reminders access denied. Please enable Reminders access in Settings."))
+                        cont.resume(throwing: ReminderToolsShared.authorizationDeniedError())
                         return
                     }
 
@@ -154,11 +226,7 @@ class MTUpdateReminderTool: ModelTool, @unchecked Sendable {
                     self.showConfirmation(
                         reminder: reminder,
                         eventStore: eventStore,
-                        newTitle: newTitle,
-                        newNotes: newNotes,
-                        newDueDate: newDueDate,
-                        newPriority: newPriority,
-                        newListName: newListName,
+                        changes: changes,
                         controller: controller,
                         continuation: cont,
                     )
@@ -167,42 +235,49 @@ class MTUpdateReminderTool: ModelTool, @unchecked Sendable {
         }
     }
 
+    static func summarizeChanges(_ changes: ParsedChanges, currentTitle: String?) -> [String] {
+        var lines: [String] = []
+        if let newTitle = changes.newTitle {
+            lines.append(String(localized: "Title: \(currentTitle ?? "-") → \(newTitle)"))
+        }
+        if changes.clearNotes {
+            lines.append(String(localized: "Notes → \(String(localized: "(cleared)"))"))
+        } else if let newNotes = changes.newNotes {
+            lines.append(String(localized: "Notes → \(newNotes)"))
+        }
+        if changes.clearDueDate {
+            lines.append(String(localized: "Due → \(String(localized: "(cleared)"))"))
+        } else if let newDueDate = changes.newDueDate {
+            lines.append(String(localized: "Due → \(newDueDate)"))
+        }
+        if changes.clearPriority {
+            lines.append(String(localized: "Priority → \(String(localized: "(cleared)"))"))
+        } else if let newPriority = changes.newPriority {
+            lines.append(String(localized: "Priority → \(ReminderToolsShared.priorityLabel(newPriority))"))
+        }
+        if let newListName = changes.newListName {
+            lines.append(String(localized: "List → \(newListName)"))
+        }
+        return lines
+    }
+
     @MainActor
     private func showConfirmation(
         reminder: EKReminder,
         eventStore: EKEventStore,
-        newTitle: String?,
-        newNotes: String?,
-        newDueDate: String?,
-        newPriority: Int?,
-        newListName: String?,
+        changes: ParsedChanges,
         controller: UIViewController,
         continuation: CheckedContinuation<String, any Swift.Error>,
     ) {
-        var changes: [String] = []
-        if let newTitle {
-            changes.append(String(localized: "Title: \(reminder.title ?? "-") → \(newTitle)"))
-        }
-        if let newNotes {
-            changes.append(String(localized: "Notes → \(newNotes)"))
-        }
-        if let newDueDate {
-            changes.append(String(localized: "Due → \(newDueDate)"))
-        }
-        if let newPriority {
-            changes.append(String(localized: "Priority → \(ReminderToolsShared.priorityLabel(newPriority))"))
-        }
-        if let newListName {
-            changes.append(String(localized: "List → \(newListName)"))
-        }
+        let summary = Self.summarizeChanges(changes, currentTitle: reminder.title)
 
-        if changes.isEmpty {
+        if summary.isEmpty {
             continuation.resume(returning: String(localized: "No changes specified; reminder left untouched."))
             return
         }
 
         let title = reminder.title ?? String(localized: "Untitled")
-        let body = title + "\n\n" + changes.joined(separator: "\n")
+        let body = title + "\n\n" + summary.joined(separator: "\n")
         let alert = AlertViewController(
             title: "Update Reminder",
             message: body,
@@ -216,26 +291,36 @@ class MTUpdateReminderTool: ModelTool, @unchecked Sendable {
             }
             context.addAction(title: "Update", attribute: .accent) {
                 context.dispose {
-                    if let newTitle { reminder.title = newTitle }
-                    if let newNotes { reminder.notes = newNotes }
-                    if let newDueDate, let date = ReminderToolsShared.parseISODate(newDueDate) {
+                    if let newTitle = changes.newTitle { reminder.title = newTitle }
+                    if changes.clearNotes {
+                        reminder.notes = nil
+                    } else if let newNotes = changes.newNotes {
+                        reminder.notes = newNotes
+                    }
+                    if changes.clearDueDate {
+                        reminder.dueDateComponents = nil
+                    } else if let newDueDate = changes.newDueDate, let date = ReminderToolsShared.parseISODate(newDueDate) {
                         reminder.dueDateComponents = Calendar.current.dateComponents(
                             [.year, .month, .day, .hour, .minute],
                             from: date,
                         )
                     }
-                    if let newPriority {
+                    if changes.clearPriority {
+                        reminder.priority = 0
+                    } else if let newPriority = changes.newPriority {
                         reminder.priority = newPriority
                     }
-                    if let newListName,
-                       let calendar = ReminderToolsShared.resolveCalendar(named: newListName, eventStore: eventStore)
-                    {
-                        reminder.calendar = calendar
-                    }
-
                     do {
+                        if let newListName = changes.newListName {
+                            reminder.calendar = try ReminderToolsShared.resolveCalendarRequiringName(
+                                named: newListName,
+                                eventStore: eventStore,
+                            )
+                        }
                         try eventStore.save(reminder, commit: true)
                         continuation.resume(returning: String(localized: "Reminder updated: \(reminder.title ?? "-")"))
+                    } catch let error as NSError where error.domain == ReminderToolsShared.errorDomain {
+                        continuation.resume(throwing: error)
                     } catch {
                         continuation.resume(throwing: NSError(domain: String(localized: "Tool"), code: -1, userInfo: [
                             NSLocalizedDescriptionKey: String(localized: "Failed to update reminder: \(error.localizedDescription)"),

--- a/FlowDown/Backend/ModelTools/ReminderTools/ReminderToolsShared.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/ReminderToolsShared.swift
@@ -9,6 +9,14 @@ import EventKit
 import Foundation
 
 enum ReminderToolsShared {
+    static let errorDomain = "MTReminderTool"
+
+    enum CalendarMatch: Equatable {
+        case useDefault
+        case matched(Int)
+        case notFound
+    }
+
     static func requestAccess(completion: @escaping (Bool) -> Void) {
         let eventStore = EKEventStore()
         if #available(iOS 17, macCatalyst 17, *) {
@@ -47,15 +55,66 @@ enum ReminderToolsShared {
         }
     }
 
-    static func resolveCalendar(named name: String, eventStore: EKEventStore) -> EKCalendar? {
+    /// Pure decision over a list of calendar titles. Empty name signals "use the
+    /// default list", a case-insensitive match returns the index, an unknown
+    /// non-empty name returns `.notFound` so callers can surface a clear error
+    /// rather than silently falling back to the default list.
+    static func matchCalendarTitle(_ name: String, in titles: [String]) -> CalendarMatch {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
-            let candidates = eventStore.calendars(for: .reminder)
-            if let match = candidates.first(where: { $0.title.caseInsensitiveCompare(trimmed) == .orderedSame }) {
-                return match
-            }
+        if trimmed.isEmpty { return .useDefault }
+        if let index = titles.firstIndex(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            return .matched(index)
         }
-        return eventStore.defaultCalendarForNewReminders()
+        return .notFound
+    }
+
+    /// Resolves the user-supplied list name to a concrete `EKCalendar`. Empty
+    /// name → the system default reminders calendar. Non-empty unmatched →
+    /// throws so a typo doesn't silently land the reminder in the default list.
+    static func resolveCalendarRequiringName(
+        named name: String,
+        eventStore: EKEventStore,
+    ) throws -> EKCalendar {
+        let candidates = eventStore.calendars(for: .reminder)
+        switch matchCalendarTitle(name, in: candidates.map(\.title)) {
+        case .useDefault:
+            guard let calendar = eventStore.defaultCalendarForNewReminders() else {
+                throw NSError(
+                    domain: errorDomain, code: 500, userInfo: [
+                        NSLocalizedDescriptionKey: String(localized: "No default Reminders list is available."),
+                    ],
+                )
+            }
+            return calendar
+        case let .matched(index):
+            return candidates[index]
+        case .notFound:
+            throw listNotFoundError(name)
+        }
+    }
+
+    static func authorizationDeniedError() -> NSError {
+        NSError(
+            domain: errorDomain, code: 403, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "Reminders access denied. Please enable Reminders access in Settings."),
+            ],
+        )
+    }
+
+    static func listNotFoundError(_ name: String) -> NSError {
+        NSError(
+            domain: errorDomain, code: 404, userInfo: [
+                NSLocalizedDescriptionKey: String(localized: "No Reminders list named \"\(name)\" found."),
+            ],
+        )
+    }
+
+    static func internalError(_ description: String) -> NSError {
+        NSError(
+            domain: errorDomain, code: 500, userInfo: [
+                NSLocalizedDescriptionKey: description,
+            ],
+        )
     }
 
     static func formatReminders(_ reminders: [EKReminder]) -> String {

--- a/FlowDown/Backend/ModelTools/ReminderTools/ReminderToolsShared.swift
+++ b/FlowDown/Backend/ModelTools/ReminderTools/ReminderToolsShared.swift
@@ -1,0 +1,125 @@
+//
+//  ReminderToolsShared.swift
+//  FlowDown
+//
+//  Created by XZB-1248 on 5/10/26.
+//
+
+import EventKit
+import Foundation
+
+enum ReminderToolsShared {
+    static func requestAccess(completion: @escaping (Bool) -> Void) {
+        let eventStore = EKEventStore()
+        if #available(iOS 17, macCatalyst 17, *) {
+            eventStore.requestFullAccessToReminders { granted, _ in completion(granted) }
+        } else {
+            eventStore.requestAccess(to: .reminder) { granted, _ in completion(granted) }
+        }
+    }
+
+    static func parseISODate(_ string: String) -> Date? {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let isoFractional = ISO8601DateFormatter()
+        isoFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = isoFractional.date(from: trimmed) { return date }
+
+        let isoStandard = ISO8601DateFormatter()
+        isoStandard.formatOptions = [.withInternetDateTime]
+        if let date = isoStandard.date(from: trimmed) { return date }
+
+        let dateOnly = ISO8601DateFormatter()
+        dateOnly.formatOptions = [.withFullDate]
+        if let date = dateOnly.date(from: trimmed) { return date }
+
+        return nil
+    }
+
+    static func priorityLabel(_ value: Int) -> String {
+        switch value {
+        case 0: String(localized: "None")
+        case 1 ... 4: String(localized: "High")
+        case 5: String(localized: "Medium")
+        case 6 ... 9: String(localized: "Low")
+        default: "\(value)"
+        }
+    }
+
+    static func resolveCalendar(named name: String, eventStore: EKEventStore) -> EKCalendar? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            let candidates = eventStore.calendars(for: .reminder)
+            if let match = candidates.first(where: { $0.title.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+                return match
+            }
+        }
+        return eventStore.defaultCalendarForNewReminders()
+    }
+
+    static func formatReminders(_ reminders: [EKReminder]) -> String {
+        if reminders.isEmpty {
+            return String(localized: "No reminders found.")
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .short
+        dateFormatter.locale = Locale.current
+
+        var grouped: [String: [EKReminder]] = [:]
+        for reminder in reminders {
+            let listName = reminder.calendar?.title ?? String(localized: "Reminders")
+            grouped[listName, default: []].append(reminder)
+        }
+
+        var lines: [String] = []
+        for listName in grouped.keys.sorted() {
+            lines.append("# \(listName)")
+            lines.append("")
+
+            let items = grouped[listName] ?? []
+            let sorted = items.sorted { lhs, rhs in
+                let lhsDate = lhs.dueDateComponents.flatMap { Calendar.current.date(from: $0) } ?? .distantFuture
+                let rhsDate = rhs.dueDateComponents.flatMap { Calendar.current.date(from: $0) } ?? .distantFuture
+                return lhsDate < rhsDate
+            }
+
+            for reminder in sorted {
+                let checkbox = reminder.isCompleted ? "[x]" : "[ ]"
+                let title = reminder.title ?? String(localized: "Untitled")
+                var meta: [String] = []
+                if let components = reminder.dueDateComponents,
+                   let date = Calendar.current.date(from: components)
+                {
+                    meta.append(String(localized: "due: \(dateFormatter.string(from: date))"))
+                }
+                let alertDates = (reminder.alarms ?? []).compactMap(\.absoluteDate)
+                if !alertDates.isEmpty {
+                    let formatted = alertDates
+                        .map { dateFormatter.string(from: $0) }
+                        .joined(separator: ", ")
+                    meta.append(String(localized: "alert: \(formatted)"))
+                }
+                if reminder.priority != 0 {
+                    meta.append(String(localized: "priority: \(priorityLabel(reminder.priority))"))
+                }
+                let metaPart = meta.isEmpty ? "" : " (" + meta.joined(separator: ", ") + ")"
+                lines.append("- \(checkbox) \(title)\(metaPart) [id: \(reminder.calendarItemIdentifier)]")
+
+                if let notes = reminder.notes, !notes.isEmpty {
+                    let firstLine = notes.split(whereSeparator: \.isNewline).first.map(String.init) ?? notes
+                    lines.append("  📝 \(firstLine)")
+                }
+            }
+            lines.append("")
+        }
+
+        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func fetchReminder(id: String, eventStore: EKEventStore) -> EKReminder? {
+        eventStore.calendarItem(withIdentifier: id) as? EKReminder
+    }
+}

--- a/FlowDown/Interface/SettingController/Permission/SettingContent+Permission.swift
+++ b/FlowDown/Interface/SettingController/Permission/SettingContent+Permission.swift
@@ -56,6 +56,12 @@ extension SettingController.SettingContent {
             $0.configure(description: "We use calendar access to allow the assistant to view, create and modify events in your calendar. Calendar data is only accessed when you explicitly use calendar-related features.")
         }
 
+        let remindersUsage = ConfigurableInfoView().with {
+            $0.configure(icon: UIImage(systemName: "checklist"))
+            $0.configure(title: "Reminders")
+            $0.configure(description: "We use Reminders access to allow the assistant to view, create, modify, complete and delete your reminders. Reminders data is only accessed when you explicitly use reminders-related features.")
+        }
+
         let locationUsage = ConfigurableInfoView().with {
             $0.configure(icon: UIImage(systemName: "location.circle"))
             $0.configure(title: "Location")
@@ -114,6 +120,22 @@ extension SettingController.SettingContent {
             ) { $0.bottom /= 2 }
             stackView.addArrangedSubview(SeparatorView())
             stackView.addArrangedSubviewWithMargin(calendarUsage)
+            stackView.addArrangedSubview(SeparatorView())
+
+            stackView.addArrangedSubviewWithMargin(
+                ConfigurableSectionFooterView().with(
+                    footer: "Please note that if you use cloud-based models to process your request, your data may be sent to your service provider.",
+                ),
+            ) { $0.top /= 2 }
+            stackView.addArrangedSubview(SeparatorView())
+
+            stackView.addArrangedSubviewWithMargin(
+                ConfigurableSectionHeaderView().with(
+                    header: "Reminders",
+                ),
+            ) { $0.bottom /= 2 }
+            stackView.addArrangedSubview(SeparatorView())
+            stackView.addArrangedSubviewWithMargin(remindersUsage)
             stackView.addArrangedSubview(SeparatorView())
 
             stackView.addArrangedSubviewWithMargin(
@@ -311,6 +333,42 @@ extension SettingController.SettingContent {
             @unknown default:
                 calendarUsage.configure(value: String(localized: "Unknown"))
                 calendarUsage.setTapBlock { _ in UIApplication.shared.openSettings() }
+            }
+
+            // 检查提醒事项权限
+            switch EKEventStore.authorizationStatus(for: .reminder) {
+            case .authorized:
+                remindersUsage.configure(value: String(localized: "Authorized"))
+                remindersUsage.setTapBlock { _ in UIApplication.shared.openSettings() }
+            case .notDetermined:
+                remindersUsage.configure(value: String(localized: "Not Determined"))
+                remindersUsage.setTapBlock { [weak self] _ in
+                    let eventStore = EKEventStore()
+                    if #available(iOS 17, macCatalyst 17, *) {
+                        eventStore.requestFullAccessToReminders { _, _ in
+                            Task { @MainActor in self?.updateValues() }
+                        }
+                    } else {
+                        eventStore.requestAccess(to: .reminder) { _, _ in
+                            Task { @MainActor in self?.updateValues() }
+                        }
+                    }
+                }
+            case .restricted:
+                remindersUsage.configure(value: String(localized: "Restricted"))
+                remindersUsage.setTapBlock { _ in UIApplication.shared.openSettings() }
+            case .denied:
+                remindersUsage.configure(value: String(localized: "Denied"), isDestructive: true)
+                remindersUsage.setTapBlock { _ in UIApplication.shared.openSettings() }
+            case .fullAccess:
+                remindersUsage.configure(value: String(localized: "Full Access"), isDestructive: true)
+                remindersUsage.setTapBlock { _ in UIApplication.shared.openSettings() }
+            case .writeOnly:
+                remindersUsage.configure(value: String(localized: "Write Only"), isDestructive: true)
+                remindersUsage.setTapBlock { _ in UIApplication.shared.openSettings() }
+            @unknown default:
+                remindersUsage.configure(value: String(localized: "Unknown"))
+                remindersUsage.setTapBlock { _ in UIApplication.shared.openSettings() }
             }
 
             // 检查位置权限 - 使用实例方法而非静态方法

--- a/FlowDown/Resources/InfoPlist.xcstrings
+++ b/FlowDown/Resources/InfoPlist.xcstrings
@@ -706,6 +706,100 @@
         }
       }
     },
+    "NSRemindersFullAccessUsageDescription" : {
+      "comment" : "Privacy - Reminders Full Access Usage Description",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown benötigt Zugriff auf Erinnerungen, damit du den Assistenten bitten kannst, deine Erinnerungen zu erstellen, anzusehen, zu ändern, abzuschließen oder zu löschen. Wenn du z. B. „Füge ‚Milch kaufen‘ morgen meinen Erinnerungen hinzu“ sagst, schreibt FlowDown die Erinnerung in deine Standard-Erinnerungsliste. Deine Erinnerungen werden nur lokal verarbeitet, um die Anfrage zu erfüllen, und nicht von FlowDown gespeichert. Bei einem cloudbasierten KI-Modell kann der relevante Erinnerungstext während der Verarbeitung an deinen ausgewählten Dienstanbieter gesendet werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown requires Reminders access so you can ask the assistant to create, view, change, complete, or delete your reminders. For example, when you ask \"Add buying milk to my reminders for tomorrow,\" FlowDown will write the reminder into your default Reminders list. Your reminders are only processed locally to fulfill the request and are not stored by FlowDown. If you're using a cloud-based AI model, the relevant reminder text may be sent to your chosen service provider during processing."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown necesita acceso a Recordatorios para que puedas pedirle al asistente crear, ver, modificar, completar o eliminar tus recordatorios. Por ejemplo, cuando dices «Añade comprar leche a mis recordatorios para mañana», FlowDown escribirá el recordatorio en tu lista predeterminada. Tus recordatorios solo se procesan localmente para cumplir la solicitud y FlowDown no los almacena. Si usas un modelo de IA en la nube, el texto del recordatorio relevante puede enviarse a tu proveedor de servicio durante el procesamiento."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown a besoin d’accéder aux Rappels pour que vous puissiez demander à l’assistant de créer, consulter, modifier, terminer ou supprimer vos rappels. Par exemple, si vous dites « Ajoute ‘acheter du lait’ demain dans mes rappels », FlowDown écrira le rappel dans votre liste par défaut. Vos rappels ne sont traités que localement pour répondre à la requête et ne sont pas stockés par FlowDown. Si vous utilisez un modèle IA dans le cloud, le texte du rappel concerné peut être envoyé à votre fournisseur de service pendant le traitement."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown は、アシスタントにリマインダーの作成・表示・変更・完了・削除を依頼できるようにするため、リマインダーへのアクセスを必要とします。例えば「明日のリマインダーに『牛乳を買う』を追加して」と頼むと、FlowDown はそのリマインダーをデフォルトのリマインダーリストに書き込みます。リマインダーのデータはこのリクエストを処理するためにローカルでのみ扱われ、FlowDown には保存されません。クラウドの AI モデルを利用する場合、関連するリマインダー本文が処理中に選択したサービスプロバイダに送信されることがあります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown은 어시스턴트가 미리 알림을 만들고 보고 수정하고 완료하고 삭제할 수 있도록 미리 알림 접근 권한이 필요합니다. 예를 들어 \"내일 미리 알림에 우유 사기 추가해줘\"라고 말하면 FlowDown은 해당 미리 알림을 기본 목록에 기록합니다. 미리 알림 데이터는 요청을 수행하기 위해 로컬에서만 처리되며 FlowDown은 저장하지 않습니다. 클라우드 기반 AI 모델을 사용하는 경우, 관련 미리 알림 텍스트가 처리 중에 선택한 서비스 제공자에게 전송될 수 있습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown 需要提醒事项权限，以便你可以让助手创建、查看、修改、完成或删除提醒事项。例如，当你说\"在我的提醒事项里加一个明天买牛奶\"时，FlowDown 会把这条提醒写入默认列表。你的提醒事项数据仅在本地处理用于完成本次请求，FlowDown 不会保存。如果你使用基于云的 AI 模型，相关提醒事项文本可能在处理过程中发送到你选择的服务提供商。"
+          }
+        }
+      }
+    },
+    "NSRemindersUsageDescription" : {
+      "comment" : "Privacy - Reminders Usage Description",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown benötigt Zugriff auf Erinnerungen, damit du den Assistenten bitten kannst, deine Erinnerungen zu erstellen, anzusehen, zu ändern, abzuschließen oder zu löschen. Wenn du z. B. „Füge ‚Milch kaufen‘ morgen meinen Erinnerungen hinzu“ sagst, schreibt FlowDown die Erinnerung in deine Standard-Erinnerungsliste. Deine Erinnerungen werden nur lokal verarbeitet, um die Anfrage zu erfüllen, und nicht von FlowDown gespeichert. Bei einem cloudbasierten KI-Modell kann der relevante Erinnerungstext während der Verarbeitung an deinen ausgewählten Dienstanbieter gesendet werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown requires Reminders access so you can ask the assistant to create, view, change, complete, or delete your reminders. For example, when you ask \"Add buying milk to my reminders for tomorrow,\" FlowDown will write the reminder into your default Reminders list. Your reminders are only processed locally to fulfill the request and are not stored by FlowDown. If you're using a cloud-based AI model, the relevant reminder text may be sent to your chosen service provider during processing."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown necesita acceso a Recordatorios para que puedas pedirle al asistente crear, ver, modificar, completar o eliminar tus recordatorios. Por ejemplo, cuando dices «Añade comprar leche a mis recordatorios para mañana», FlowDown escribirá el recordatorio en tu lista predeterminada. Tus recordatorios solo se procesan localmente para cumplir la solicitud y FlowDown no los almacena. Si usas un modelo de IA en la nube, el texto del recordatorio relevante puede enviarse a tu proveedor de servicio durante el procesamiento."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown a besoin d’accéder aux Rappels pour que vous puissiez demander à l’assistant de créer, consulter, modifier, terminer ou supprimer vos rappels. Par exemple, si vous dites « Ajoute ‘acheter du lait’ demain dans mes rappels », FlowDown écrira le rappel dans votre liste par défaut. Vos rappels ne sont traités que localement pour répondre à la requête et ne sont pas stockés par FlowDown. Si vous utilisez un modèle IA dans le cloud, le texte du rappel concerné peut être envoyé à votre fournisseur de service pendant le traitement."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown は、アシスタントにリマインダーの作成・表示・変更・完了・削除を依頼できるようにするため、リマインダーへのアクセスを必要とします。例えば「明日のリマインダーに『牛乳を買う』を追加して」と頼むと、FlowDown はそのリマインダーをデフォルトのリマインダーリストに書き込みます。リマインダーのデータはこのリクエストを処理するためにローカルでのみ扱われ、FlowDown には保存されません。クラウドの AI モデルを利用する場合、関連するリマインダー本文が処理中に選択したサービスプロバイダに送信されることがあります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown은 어시스턴트가 미리 알림을 만들고 보고 수정하고 완료하고 삭제할 수 있도록 미리 알림 접근 권한이 필요합니다. 예를 들어 \"내일 미리 알림에 우유 사기 추가해줘\"라고 말하면 FlowDown은 해당 미리 알림을 기본 목록에 기록합니다. 미리 알림 데이터는 요청을 수행하기 위해 로컬에서만 처리되며 FlowDown은 저장하지 않습니다. 클라우드 기반 AI 모델을 사용하는 경우, 관련 미리 알림 텍스트가 처리 중에 선택한 서비스 제공자에게 전송될 수 있습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FlowDown 需要提醒事项权限，以便你可以让助手创建、查看、修改、完成或删除提醒事项。例如，当你说\"在我的提醒事项里加一个明天买牛奶\"时，FlowDown 会把这条提醒写入默认列表。你的提醒事项数据仅在本地处理用于完成本次请求，FlowDown 不会保存。如果你使用基于云的 AI 模型，相关提醒事项文本可能在处理过程中发送到你选择的服务提供商。"
+          }
+        }
+      }
+    },
     "NSSpeechRecognitionUsageDescription" : {
       "comment" : "Privacy - Speech Recognition Usage Description",
       "localizations" : {

--- a/FlowDown/Resources/Localizable.xcstrings
+++ b/FlowDown/Resources/Localizable.xcstrings
@@ -44982,6 +44982,52 @@
         }
       }
     },
+    "start_date must be on or before end_date." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date muss vor oder gleich end_date liegen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date must be on or before end_date."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date debe ser igual o anterior a end_date."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date doit être antérieur ou égal à end_date."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date は end_date 以前である必要があります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date는 end_date보다 같거나 빠른 날짜여야 합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date 必须早于或等于 end_date。"
+          }
+        }
+      }
+    },
     "Start: %@" : {
       "localizations" : {
         "de" : {

--- a/FlowDown/Resources/Localizable.xcstrings
+++ b/FlowDown/Resources/Localizable.xcstrings
@@ -1,6 +1,52 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "(cleared)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(geleert)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(cleared)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(borrado)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(effacé)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(クリア)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(지움)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（已清空）"
+          }
+        }
+      }
+    },
     "(No Content)" : {
       "localizations" : {
         "de" : {
@@ -1151,6 +1197,52 @@
         }
       }
     },
+    "A non-empty title is required." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein nicht leerer Titel ist erforderlich."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A non-empty title is required."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se requiere un título no vacío."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un titre non vide est requis."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空でないタイトルが必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비어 있지 않은 제목이 필요합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "必须提供非空标题。"
+          }
+        }
+      }
+    },
     "A proactive memory summary has been provided above according to the user's setting. Treat it as reliable context and keep it updated through memory tools when necessary." : {
       "localizations" : {
         "de" : {
@@ -1842,6 +1934,52 @@
         }
       }
     },
+    "Add to Reminders" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zu Erinnerungen hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add to Reminders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir a Recordatorios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter aux Rappels"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーに追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림에 추가"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加提醒事项"
+          }
+        }
+      }
+    },
     "Additional Prompt" : {
       "localizations" : {
         "de" : {
@@ -2068,6 +2206,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "协议"
+          }
+        }
+      }
+    },
+    "alert: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "alert: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "alerta: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "alerte : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提醒：%@"
           }
         }
       }
@@ -2670,6 +2854,98 @@
         }
       }
     },
+    "Allows LLM to create reminders in your system Reminders." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt dem LLM, Einträge in deinen System-Erinnerungen zu erstellen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allows LLM to create reminders in your system Reminders."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que el LLM cree recordatorios en tu app Recordatorios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorise le LLM à créer des rappels dans votre app Rappels."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM がシステムのリマインダーに項目を作成できるようにします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM이 시스템 미리 알림에 항목을 만들도록 허용합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许大语言模型在系统提醒事项中创建条目。"
+          }
+        }
+      }
+    },
+    "Allows LLM to delete reminders. The user is asked to confirm each deletion." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt dem LLM, Erinnerungen zu löschen. Vor jeder Löschung wird bestätigt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allows LLM to delete reminders. The user is asked to confirm each deletion."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que el LLM elimine recordatorios. Se solicitará confirmación antes de cada eliminación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorise le LLM à supprimer des rappels. Une confirmation est demandée avant chaque suppression."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM がリマインダーを削除できるようにします。削除のたびに確認を求めます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM이 미리 알림을 삭제할 수 있도록 허용합니다. 삭제할 때마다 확인을 요청합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许大语言模型删除提醒事项。每次删除前都会请求确认。"
+          }
+        }
+      }
+    },
     "Allows LLM to fetch and read content from web pages." : {
       "localizations" : {
         "de" : {
@@ -2716,6 +2992,98 @@
         }
       }
     },
+    "Allows LLM to mark reminders as completed." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt dem LLM, Erinnerungen als erledigt zu markieren."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allows LLM to mark reminders as completed."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que el LLM marque recordatorios como completados."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorise le LLM à marquer les rappels comme terminés."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM がリマインダーを完了済みにマークできるようにします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM이 미리 알림을 완료로 표시할 수 있도록 허용합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许大语言模型将提醒事项标记为完成。"
+          }
+        }
+      }
+    },
+    "Allows LLM to modify reminders, including marking them as complete." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt dem LLM, Erinnerungen zu ändern, einschließlich des Markierens als erledigt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allows LLM to modify reminders, including marking them as complete."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que el LLM modifique recordatorios, incluido marcarlos como completados."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorise le LLM à modifier les rappels, y compris à les marquer comme terminés."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM がリマインダーを変更できるようにします（完了マークを含む）。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM이 미리 알림을 수정하고 완료로 표시할 수 있도록 허용합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许大语言模型修改提醒事项，包括标记为完成。"
+          }
+        }
+      }
+    },
     "Allows LLM to read your calendar events." : {
       "localizations" : {
         "de" : {
@@ -2758,6 +3126,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允许大语言模型读取你的日历数据。"
+          }
+        }
+      }
+    },
+    "Allows LLM to read your reminders." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erlaubt dem LLM, deine Erinnerungen zu lesen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allows LLM to read your reminders."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permite que el LLM lea tus recordatorios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorise le LLM à lire vos rappels."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM がリマインダーを読み取れるようにします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM이 미리 알림을 읽도록 허용합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许大语言模型读取你的提醒事项。"
           }
         }
       }
@@ -8249,6 +8663,52 @@
         }
       }
     },
+    "Complete Reminder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung abschließen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete Reminder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completar recordatorio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminer le rappel"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを完了"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림 완료"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成提醒事项"
+          }
+        }
+      }
+    },
     "Completed" : {
       "localizations" : {
         "de" : {
@@ -12343,6 +12803,52 @@
         }
       }
     },
+    "Date range cannot exceed 365 days" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Datumsbereich darf 365 Tage nicht überschreiten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date range cannot exceed 365 days"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El rango de fechas no puede superar los 365 días"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La plage de dates ne peut pas dépasser 365 jours"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付範囲は 365 日を超えられません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜 범위는 365일을 초과할 수 없습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期范围不能超过 365 天"
+          }
+        }
+      }
+    },
     "Default" : {
       "localizations" : {
         "de" : {
@@ -13121,6 +13627,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除模型"
+          }
+        }
+      }
+    },
+    "Delete Reminder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung löschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Reminder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar recordatorio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le rappel"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림 삭제"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除提醒事项"
           }
         }
       }
@@ -14562,6 +15114,52 @@
         }
       }
     },
+    "Due → %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fällig → %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Due → %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vence → %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échéance → %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "期限 → %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기한 → %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期 → %@"
+          }
+        }
+      }
+    },
     "Due to system limitations, you must enable audio to use this feature." : {
       "localizations" : {
         "de" : {
@@ -14604,6 +15202,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "由于系统限制，你必须启用音频才能使用此功能。"
+          }
+        }
+      }
+    },
+    "due: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "fällig: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "due: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vence: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "échéance : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "期限: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기한: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期：%@"
+          }
+        }
+      }
+    },
+    "Due: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fällig: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Due: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vence: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échéance : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "期限: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기한: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期：%@"
           }
         }
       }
@@ -17311,6 +18001,52 @@
         }
       }
     },
+    "Exiting now will interrupt the running conversation." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn Sie jetzt beenden, wird die laufende Konversation unterbrochen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exiting now will interrupt the running conversation."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si sales ahora, se interrumpirá la conversación en curso."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitter maintenant interrompra la conversation en cours."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐ終了すると、進行中の会話が中断されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지금 종료하면 진행 중인 대화가 중단됩니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "现在退出会中断正在进行的对话。"
+          }
+        }
+      }
+    },
     "Exiting now will interrupt the running evaluation." : {
       "localizations" : {
         "de" : {
@@ -18737,6 +19473,52 @@
         }
       }
     },
+    "Failed to add reminder: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler beim Hinzufügen der Erinnerung: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to add reminder: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo añadir el recordatorio: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’ajouter le rappel : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーの追加に失敗しました: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림을 추가하지 못했습니다: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加提醒事项失败：%@"
+          }
+        }
+      }
+    },
     "Failed to clear memories: %@" : {
       "localizations" : {
         "de" : {
@@ -18963,6 +19745,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法删除记忆：%@"
+          }
+        }
+      }
+    },
+    "Failed to delete reminder: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler beim Löschen der Erinnerung: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to delete reminder: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo eliminar el recordatorio: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de supprimer le rappel : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーの削除に失敗しました: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림을 삭제하지 못했습니다: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除提醒事项失败：%@"
           }
         }
       }
@@ -19929,6 +20757,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法更新记忆：%@"
+          }
+        }
+      }
+    },
+    "Failed to update reminder: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler beim Aktualisieren der Erinnerung: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to update reminder: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo actualizar el recordatorio: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de mettre à jour le rappel : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーの更新に失敗しました: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림을 업데이트하지 못했습니다: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新提醒事项失败：%@"
           }
         }
       }
@@ -21966,6 +22840,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "报文头"
+          }
+        }
+      }
+    },
+    "High" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "High"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élevée"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "높음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高"
           }
         }
       }
@@ -24732,6 +25652,98 @@
         }
       }
     },
+    "Invalid due_date format. Use ISO 8601 UTC." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiges due_date-Format. Verwende ISO 8601 UTC."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid due_date format. Use ISO 8601 UTC."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formato de due_date no válido. Usa ISO 8601 UTC."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format due_date invalide. Utilisez ISO 8601 UTC."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "due_date の形式が無効です。ISO 8601 UTC を使用してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "due_date 형식이 잘못되었습니다. ISO 8601 UTC를 사용하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "due_date 格式无效。请使用 ISO 8601 UTC。"
+          }
+        }
+      }
+    },
+    "Invalid end_date format. Use ISO 8601 UTC." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiges end_date-Format. Verwende ISO 8601 UTC."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid end_date format. Use ISO 8601 UTC."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formato de end_date no válido. Usa ISO 8601 UTC."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format end_date invalide. Utilisez ISO 8601 UTC."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "end_date の形式が無効です。ISO 8601 UTC を使用してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "end_date 형식이 잘못되었습니다. ISO 8601 UTC를 사용하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "end_date 格式无效。请使用 ISO 8601 UTC。"
+          }
+        }
+      }
+    },
     "Invalid ICS file content" : {
       "localizations" : {
         "de" : {
@@ -25096,6 +26108,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无效的日期格式：请使用 YYYY-MM-DD。"
+          }
+        }
+      }
+    },
+    "Invalid start_date format. Use ISO 8601 UTC." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiges start_date-Format. Verwende ISO 8601 UTC."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid start_date format. Use ISO 8601 UTC."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formato de start_date no válido. Usa ISO 8601 UTC."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format start_date invalide. Utilisez ISO 8601 UTC."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date の形式が無効です。ISO 8601 UTC を使用してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date 형식이 잘못되었습니다. ISO 8601 UTC를 사용하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "start_date 格式无效。请使用 ISO 8601 UTC。"
           }
         }
       }
@@ -25986,6 +27044,52 @@
         }
       }
     },
+    "List → %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste → %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "List → %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista → %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste → %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リスト → %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목록 → %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列表 → %@"
+          }
+        }
+      }
+    },
     "List Key Points" : {
       "localizations" : {
         "de" : {
@@ -26166,6 +27270,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用默认模型列出关键要点"
+          }
+        }
+      }
+    },
+    "List: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "List: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リスト: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목록: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列表：%@"
           }
         }
       }
@@ -26861,6 +28011,52 @@
         }
       }
     },
+    "Low" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niedrig"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Low"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baja"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "낮음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低"
+          }
+        }
+      }
+    },
     "Magical @ 2.0" : {
       "localizations" : {
         "de" : {
@@ -27321,6 +28517,52 @@
         }
       }
     },
+    "Mark as Done" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Als erledigt markieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark as Done"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar como hecho"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme terminé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료로 표시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标记为完成"
+          }
+        }
+      }
+    },
     "Mark as Failure" : {
       "localizations" : {
         "de" : {
@@ -27367,6 +28609,52 @@
         }
       }
     },
+    "Mark as Not Done" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Als nicht erledigt markieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark as Not Done"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar como no hecho"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme non terminé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未完了にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미완료로 표시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标记为未完成"
+          }
+        }
+      }
+    },
     "Mark as Success" : {
       "localizations" : {
         "de" : {
@@ -27409,6 +28697,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标记为成功"
+          }
+        }
+      }
+    },
+    "Mark Done" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erledigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark Done"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar hecho"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标记完成"
           }
         }
       }
@@ -30176,6 +31510,52 @@
         }
       }
     },
+    "More reminders available" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weitere Erinnerungen verfügbar"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More reminders available"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hay más recordatorios disponibles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus de rappels disponibles"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "さらにリマインダーがあります"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "더 많은 미리 알림이 있습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还有更多提醒事项"
+          }
+        }
+      }
+    },
     "Name" : {
       "localizations" : {
         "de" : {
@@ -30827,6 +32207,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无分类"
+          }
+        }
+      }
+    },
+    "No changes specified; reminder left untouched." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Änderungen angegeben; die Erinnerung bleibt unverändert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No changes specified; reminder left untouched."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se especificaron cambios; el recordatorio queda intacto."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune modification spécifiée ; le rappel n’a pas été modifié."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更が指定されていません。リマインダーはそのままです。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "변경 사항이 지정되지 않아 미리 알림을 그대로 두었습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未指定任何更改；提醒事项保持不变。"
           }
         }
       }
@@ -31659,6 +33085,98 @@
         }
       }
     },
+    "No reminders found." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Erinnerungen gefunden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No reminders found."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron recordatorios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun rappel trouvé."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーが見つかりません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림을 찾을 수 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到任何提醒事项。"
+          }
+        }
+      }
+    },
+    "No Reminders list named \"%@\" found." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Erinnerungsliste mit Namen „%@“ gefunden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Reminders list named \"%@\" found."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontró ninguna lista de Recordatorios llamada «%@»."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune liste de Rappels nommée « %@ » trouvée."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」という名前のリマインダーリストが見つかりません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」(이)라는 이름의 미리 알림 목록을 찾을 수 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到名为「%@」的提醒事项列表。"
+          }
+        }
+      }
+    },
     "No response from model." : {
       "localizations" : {
         "de" : {
@@ -32115,6 +33633,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知"
+          }
+        }
+      }
+    },
+    "Notes → %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notizen → %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes → %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notas → %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes → %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモ → %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메모 → %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "备注 → %@"
+          }
+        }
+      }
+    },
+    "Notes: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notizen: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notas: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモ: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메모: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "备注：%@"
           }
         }
       }
@@ -35456,6 +37066,144 @@
         }
       }
     },
+    "Priority → %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorität → %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priority → %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prioridad → %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorité → %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先度 → %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "우선순위 → %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "优先级 → %@"
+          }
+        }
+      }
+    },
+    "priority: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "priorität: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "priority: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "prioridad: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "priorité : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先度: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "우선순위: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "优先级：%@"
+          }
+        }
+      }
+    },
+    "Priority: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorität: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priority: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prioridad: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priorité : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先度: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "우선순위: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "优先级：%@"
+          }
+        }
+      }
+    },
     "Privacy First" : {
       "localizations" : {
         "de" : {
@@ -36189,6 +37937,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询日历"
+          }
+        }
+      }
+    },
+    "Query Reminders" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerungen abfragen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query Reminders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consultar recordatorios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interroger les rappels"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを照会"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림 조회"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询提醒事项"
           }
         }
       }
@@ -37247,6 +39041,420 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正则：'%@'"
+          }
+        }
+      }
+    },
+    "Reminder added: %@ [id: %@]" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung hinzugefügt: %1$@ [id: %2$@]"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder added: %1$@ [id: %2$@]"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recordatorio añadido: %1$@ [id: %2$@]"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappel ajouté : %1$@ [id : %2$@]"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを追加しました: %1$@ [id: %2$@]"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림이 추가되었습니다: %1$@ [id: %2$@]"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已添加提醒事项：%1$@ [id: %2$@]"
+          }
+        }
+      }
+    },
+    "Reminder deleted: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung gelöscht: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder deleted: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recordatorio eliminado: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappel supprimé : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを削除しました: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림이 삭제되었습니다: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已删除提醒事项：%@"
+          }
+        }
+      }
+    },
+    "Reminder marked completed: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung als erledigt markiert: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder marked completed: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recordatorio marcado como completado: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappel marqué comme terminé : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを完了にしました: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림을 완료로 표시했습니다: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已将提醒事项标记为完成：%@"
+          }
+        }
+      }
+    },
+    "Reminder marked uncompleted: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung als nicht erledigt markiert: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder marked uncompleted: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recordatorio marcado como no completado: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappel marqué comme non terminé : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを未完了にしました: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림을 미완료로 표시했습니다: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已将提醒事项标记为未完成：%@"
+          }
+        }
+      }
+    },
+    "Reminder updated: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung aktualisiert: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder updated: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recordatorio actualizado: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappel mis à jour : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを更新しました: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림이 업데이트되었습니다: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已更新提醒事项：%@"
+          }
+        }
+      }
+    },
+    "Reminder with id %@ not found." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung mit id %@ nicht gefunden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder with id %@ not found."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontró el recordatorio con id %@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappel introuvable pour l’id %@."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "id %@ のリマインダーが見つかりません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "id %@ 인 미리 알림을 찾을 수 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 id 为 %@ 的提醒事项。"
+          }
+        }
+      }
+    },
+    "reminder_id is required." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reminder_id ist erforderlich."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reminder_id is required."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se requiere reminder_id."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reminder_id est requis."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reminder_id が必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "reminder_id가 필요합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 reminder_id。"
+          }
+        }
+      }
+    },
+    "Reminders" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recordatorios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappels"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提醒事项"
+          }
+        }
+      }
+    },
+    "Reminders access denied. Please enable Reminders access in Settings." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zugriff auf Erinnerungen verweigert. Aktiviere den Zugriff in den Einstellungen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminders access denied. Please enable Reminders access in Settings."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso a Recordatorios denegado. Habilita el acceso a Recordatorios en Ajustes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accès aux Rappels refusé. Activez l’accès aux Rappels dans les Réglages."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーへのアクセスが拒否されました。設定でリマインダーへのアクセスを有効にしてください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림 접근이 거부되었습니다. 설정에서 미리 알림 접근을 활성화하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提醒事项访问被拒绝。请在「设置」中启用提醒事项访问。"
           }
         }
       }
@@ -47697,6 +49905,52 @@
         }
       }
     },
+    "This cannot be undone." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dies kann nicht rückgängig gemacht werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This cannot be undone."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto no se puede deshacer."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette action est irréversible."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この操作は取り消せません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 작업은 되돌릴 수 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作无法撤销。"
+          }
+        }
+      }
+    },
     "This conversation is based on the template: %@." : {
       "localizations" : {
         "de" : {
@@ -48901,6 +51155,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标题"
+          }
+        }
+      }
+    },
+    "Title: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titel: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Título: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제목: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标题：%@"
+          }
+        }
+      }
+    },
+    "Title: %@ → %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titel: %1$@ → %2$@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title: %1$@ → %2$@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Título: %1$@ → %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre : %1$@ → %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル: %1$@ → %2$@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제목: %1$@ → %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标题：%1$@ → %2$@"
           }
         }
       }
@@ -50799,6 +53145,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在此输入…"
+          }
+        }
+      }
+    },
+    "Un-complete" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederherstellen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un-complete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desmarcar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler la complétion"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未完了に戻す"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료 취소"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消完成"
           }
         }
       }
@@ -52735,6 +55127,52 @@
         }
       }
     },
+    "Update Reminder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erinnerung aktualisieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update Reminder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar recordatorio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mettre à jour le rappel"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーを更新"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리 알림 업데이트"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新提醒事项"
+          }
+        }
+      }
+    },
     "Update Requested" : {
       "localizations" : {
         "de" : {
@@ -53605,6 +56043,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用户取消了数据共享。"
+          }
+        }
+      }
+    },
+    "User cancelled sharing reminders." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teilen der Erinnerungen abgebrochen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "User cancelled sharing reminders."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El usuario canceló compartir los recordatorios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’utilisateur a annulé le partage des rappels."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リマインダーの共有はユーザーによって取り消されました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자가 미리 알림 공유를 취소했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用户取消了分享提醒事项。"
           }
         }
       }
@@ -55307,6 +57791,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "我们使用你的日历权限以提供数据给助手查看或修改。这些数据仅在明确请求时提供。"
+          }
+        }
+      }
+    },
+    "We use Reminders access to allow the assistant to view, create, modify, complete and delete your reminders. Reminders data is only accessed when you explicitly use reminders-related features." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wir nutzen den Zugriff auf Erinnerungen, damit der Assistent deine Erinnerungen ansehen, erstellen, ändern, abschließen und löschen kann. Auf Erinnerungsdaten wird nur zugegriffen, wenn du ausdrücklich erinnerungsbezogene Funktionen verwendest."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We use Reminders access to allow the assistant to view, create, modify, complete and delete your reminders. Reminders data is only accessed when you explicitly use reminders-related features."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usamos el acceso a Recordatorios para permitir que el asistente vea, cree, modifique, complete y elimine tus recordatorios. Los datos de Recordatorios solo se acceden cuando usas explícitamente funciones relacionadas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nous utilisons l’accès aux Rappels pour permettre à l’assistant de consulter, créer, modifier, terminer et supprimer vos rappels. Les données ne sont consultées que lorsque vous utilisez explicitement les fonctions liées aux rappels."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アシスタントがリマインダーの閲覧、作成、変更、完了、削除を行えるようにするために、リマインダーへのアクセスを使用します。リマインダー関連機能を明示的に使用したときにのみアクセスされます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "어시스턴트가 미리 알림을 보고, 만들고, 수정하고, 완료하고, 삭제할 수 있도록 미리 알림 접근 권한을 사용합니다. 미리 알림 관련 기능을 명시적으로 사용할 때만 접근합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我们使用提醒事项权限以便助手能够查看、创建、修改、完成和删除你的提醒事项。仅在你显式使用提醒事项相关功能时才会访问相关数据。"
           }
         }
       }
@@ -57617,52 +60147,6 @@
         }
       },
       "shouldTranslate" : false
-    },
-    "Exiting now will interrupt the running conversation." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exiting now will interrupt the running conversation."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn Sie jetzt beenden, wird die laufende Konversation unterbrochen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si sales ahora, se interrumpirá la conversación en curso."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitter maintenant interrompra la conversation en cours."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今すぐ終了すると、進行中の会話が中断されます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "지금 종료하면 진행 중인 대화가 중단됩니다."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "现在退出会中断正在进行的对话。"
-          }
-        }
-      }
     }
   },
   "version" : "1.0"

--- a/FlowDownUnitTests/OnlineE2ETestSupport.swift
+++ b/FlowDownUnitTests/OnlineE2ETestSupport.swift
@@ -220,10 +220,20 @@ enum OnlineE2ETestSupport {
         let currentHome = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
         let hostHome = URL(fileURLWithPath: "/Users", isDirectory: true)
             .appendingPathComponent(NSUserName(), isDirectory: true)
+        // Inside the iOS simulator, NSHomeDirectory() points at the app sandbox
+        // and NSUserName() returns the numeric uid, so the two ~/.testing
+        // candidates above never resolve to the host's secrets directory. The
+        // test wrapper at run_online_e2e_tests.sh therefore mirrors the
+        // credentials into /tmp/flowdown-online-e2e/, which the host shares
+        // with the simulator. Probe that path so live secrets reach the test
+        // runner in CI and locally.
+        let runtimeRoot = URL(fileURLWithPath: "/tmp/flowdown-online-e2e", isDirectory: true)
+        let testingPaths = [currentHome, hostHome]
+            .map { $0.appendingPathComponent(".testing").appendingPathComponent(filename) }
+        let runtimePath = runtimeRoot.appendingPathComponent(filename)
 
         var seenPaths = Set<String>()
-        return [currentHome, hostHome]
-            .map { $0.appendingPathComponent(".testing").appendingPathComponent(filename) }
+        return (testingPaths + [runtimePath])
             .filter { seenPaths.insert($0.standardizedFileURL.path).inserted }
     }
 

--- a/FlowDownUnitTests/OnlineE2ETestSupport.swift
+++ b/FlowDownUnitTests/OnlineE2ETestSupport.swift
@@ -12,9 +12,9 @@ enum OnlineE2ETestSupport {
     // Endpoint and token are provided via environment variables (backed by
     // GitHub secrets in CI or a local ~/.testing file). The model identifier,
     // headers, body fields, and capabilities below track the exported
-    // kimi-k2p5-turbo .fdmodel but can still be overridden via env.
+    // kimi-k2p6-turbo .fdmodel but can still be overridden via env.
     private static let embeddedFixture = EmbeddedCloudModelFixture(
-        modelIdentifier: "kimi-k2p5-turbo",
+        modelIdentifier: "kimi-k2p6-turbo",
         headers: [
             "HTTP-Referer": "https://flowdown.ai/",
             "X-Title": "FlowDown",

--- a/FlowDownUnitTests/OnlineReminderToolsE2ETests.swift
+++ b/FlowDownUnitTests/OnlineReminderToolsE2ETests.swift
@@ -1,0 +1,298 @@
+@testable import ChatClientKit
+@testable import FlowDown
+import Foundation
+import Testing
+
+/// Live, network-touching coverage that proves each Reminders tool's JSON
+/// schema is concrete enough that the backing model produces a syntactically
+/// valid tool call against it. This catches regressions where adding new
+/// schema fields (e.g. `clear_*` flags) makes the tool unusable by the LLM.
+///
+/// The model only sees the tool definitions; we never let it execute against
+/// real EventKit. Tool outputs are stubbed with placeholder strings.
+@Suite(.serialized)
+struct OnlineReminderToolsE2ETests {
+    static let responseFormats: [CloudModel.ResponseFormat] = [.chatCompletions, .responses]
+
+    // MARK: Client factory
+
+    private func makeClient(for responseFormat: CloudModel.ResponseFormat) throws -> any ChatService {
+        switch responseFormat {
+        case .chatCompletions:
+            return try OnlineE2ETestSupport.makeCompletionsClient()
+        case .responses:
+            return try OnlineE2ETestSupport.makeResponsesClient()
+        }
+    }
+
+    private func collect(
+        _ client: any ChatService,
+        body: ChatRequestBody,
+    ) async throws -> ChatResponse {
+        try await retryingTransientErrors {
+            let stream = try await client.streamingChat(body: body)
+            var chunks: [ChatResponseChunk] = []
+            for try await chunk in stream {
+                chunks.append(chunk)
+            }
+            return ChatResponse(chunks: chunks)
+        }
+    }
+
+    private func retryingTransientErrors<T>(
+        maxAttempts: Int = 3,
+        operation: @escaping () async throws -> T,
+    ) async throws -> T {
+        precondition(maxAttempts > 0)
+        var lastError: Error?
+        for attempt in 1 ... maxAttempts {
+            do {
+                return try await operation()
+            } catch {
+                lastError = error
+                guard attempt < maxAttempts, isTransientNetworkError(error) else { throw error }
+                try await Task.sleep(for: .seconds(Double(attempt)))
+            }
+        }
+        throw lastError ?? CancellationError()
+    }
+
+    private func isTransientNetworkError(_ error: Error) -> Bool {
+        let ns = error as NSError
+        if ns.domain == NSURLErrorDomain {
+            return [
+                NSURLErrorTimedOut,
+                NSURLErrorNetworkConnectionLost,
+                NSURLErrorCannotConnectToHost,
+                NSURLErrorCannotFindHost,
+                NSURLErrorDNSLookupFailed,
+                NSURLErrorResourceUnavailable,
+            ].contains(ns.code)
+        }
+        if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? Error {
+            return isTransientNetworkError(underlying)
+        }
+        return false
+    }
+
+    private func parsedArgs(_ raw: String) -> [String: Any] {
+        guard let data = raw.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [:] }
+        return object
+    }
+
+    // MARK: - add_reminder
+
+    @Test(.enabled(if: OnlineE2ETestSupport.isEnabled), arguments: OnlineReminderToolsE2ETests.responseFormats)
+    func `add_reminder schema yields a well-formed tool call`(
+        responseFormat: CloudModel.ResponseFormat,
+    ) async throws {
+        try #require(OnlineE2ETestSupport.isEnabled(for: responseFormat))
+
+        let client = try makeClient(for: responseFormat)
+        let tool = MTAddReminderTool().definition
+        let prompt = """
+        Use the add_reminder tool exactly once to schedule a reminder titled "Buy oat milk" with notes "2 liters from the corner store" and a due date of 2026-05-12T09:00:00Z. Use the default Reminders list (pass an empty list_name) and priority 5. Then stop.
+        """
+
+        let response = try await collect(
+            client,
+            body: ChatRequestBody(
+                messages: [.user(content: .text(prompt))],
+                maxCompletionTokens: 256,
+                temperature: 0,
+                tools: [tool],
+            ),
+        )
+
+        let call = try #require(response.tools.first, "Expected the model to issue a tool call.")
+        #expect(call.name == "add_reminder")
+
+        let args = parsedArgs(call.args)
+        let title = try #require(args["title"] as? String, "title field missing or not a string")
+        #expect(title.localizedCaseInsensitiveContains("oat milk"))
+        #expect(args["notes"] as? String != nil)
+        #expect(args["due_date"] as? String != nil)
+        #expect(args["priority"] as? Int != nil || args["priority"] as? Double != nil)
+        #expect(args["list_name"] as? String != nil)
+    }
+
+    // MARK: - query_reminders
+
+    @Test(.enabled(if: OnlineE2ETestSupport.isEnabled), arguments: OnlineReminderToolsE2ETests.responseFormats)
+    func `query_reminders schema yields a well-formed tool call`(
+        responseFormat: CloudModel.ResponseFormat,
+    ) async throws {
+        try #require(OnlineE2ETestSupport.isEnabled(for: responseFormat))
+
+        let client = try makeClient(for: responseFormat)
+        let tool = MTQueryReminderTool().definition
+        let prompt = """
+        Use the query_reminders tool exactly once to list every incomplete reminder in the user's "Inbox" list with no date filters applied. Pass empty strings for all date bounds. Then stop.
+        """
+
+        let response = try await collect(
+            client,
+            body: ChatRequestBody(
+                messages: [.user(content: .text(prompt))],
+                maxCompletionTokens: 256,
+                temperature: 0,
+                tools: [tool],
+            ),
+        )
+
+        let call = try #require(response.tools.first, "Expected the model to issue a tool call.")
+        #expect(call.name == "query_reminders")
+
+        let args = parsedArgs(call.args)
+        let status = try #require(args["status"] as? String)
+        #expect(["incomplete", "completed", "all"].contains(status))
+        #expect(args["list_name"] as? String != nil)
+        for key in [
+            "due_start_date", "due_end_date",
+            "alert_start_date", "alert_end_date",
+            "completed_start_date", "completed_end_date",
+        ] {
+            #expect(args[key] as? String != nil, "Missing required field \(key)")
+        }
+    }
+
+    // MARK: - update_reminder (clear flags)
+
+    @Test(.enabled(if: OnlineE2ETestSupport.isEnabled), arguments: OnlineReminderToolsE2ETests.responseFormats)
+    func `update_reminder schema includes clear flags and round-trips a clear request`(
+        responseFormat: CloudModel.ResponseFormat,
+    ) async throws {
+        try #require(OnlineE2ETestSupport.isEnabled(for: responseFormat))
+
+        let client = try makeClient(for: responseFormat)
+        let tool = MTUpdateReminderTool().definition
+        let prompt = """
+        The user already ran query_reminders and got a reminder whose id is "test-reminder-id-1234". Use the update_reminder tool exactly once to remove the existing notes from that reminder and set its priority to none. Leave every other field unchanged. Use the clear_* boolean flags for the fields you want to clear, and pass empty string / -1 plus clear_*=false for fields you want to leave alone. Then stop.
+        """
+
+        let response = try await collect(
+            client,
+            body: ChatRequestBody(
+                messages: [.user(content: .text(prompt))],
+                maxCompletionTokens: 256,
+                temperature: 0,
+                tools: [tool],
+            ),
+        )
+
+        let call = try #require(response.tools.first, "Expected a tool call from the model.")
+        #expect(call.name == "update_reminder")
+
+        let args = parsedArgs(call.args)
+        let reminderId = try #require(args["reminder_id"] as? String)
+        #expect(reminderId.contains("1234"))
+
+        // The required-list in strict schema must produce all clear_* keys.
+        for key in ["clear_notes", "clear_due_date", "clear_priority"] {
+            #expect(args[key] as? Bool != nil, "Missing required boolean field \(key)")
+        }
+        let clearNotes = (args["clear_notes"] as? Bool) ?? false
+        let clearPriority = (args["clear_priority"] as? Bool) ?? false
+        #expect(clearNotes, "Model should set clear_notes=true given the prompt")
+        #expect(clearPriority, "Model should set clear_priority=true given the prompt")
+
+        // Sanity: parseChanges accepts whatever the model produced.
+        var enriched = args
+        enriched["reminder_id"] = reminderId
+        let normalized = normalize(args: enriched)
+        _ = try MTUpdateReminderTool.parseChanges(from: normalized)
+    }
+
+    // MARK: - delete_reminder
+
+    @Test(.enabled(if: OnlineE2ETestSupport.isEnabled), arguments: OnlineReminderToolsE2ETests.responseFormats)
+    func `delete_reminder schema yields a well-formed tool call`(
+        responseFormat: CloudModel.ResponseFormat,
+    ) async throws {
+        try #require(OnlineE2ETestSupport.isEnabled(for: responseFormat))
+
+        let client = try makeClient(for: responseFormat)
+        let tool = MTDeleteReminderTool().definition
+        let prompt = """
+        The user already ran query_reminders. Use the delete_reminder tool exactly once to delete the reminder whose id is "test-reminder-id-DELETE". Then stop.
+        """
+
+        let response = try await collect(
+            client,
+            body: ChatRequestBody(
+                messages: [.user(content: .text(prompt))],
+                maxCompletionTokens: 128,
+                temperature: 0,
+                tools: [tool],
+            ),
+        )
+
+        let call = try #require(response.tools.first, "Expected a tool call from the model.")
+        #expect(call.name == "delete_reminder")
+        let args = parsedArgs(call.args)
+        let id = try #require(args["reminder_id"] as? String)
+        #expect(id.contains("DELETE"))
+    }
+
+    // MARK: - complete_reminder
+
+    @Test(.enabled(if: OnlineE2ETestSupport.isEnabled), arguments: OnlineReminderToolsE2ETests.responseFormats)
+    func `complete_reminder schema yields a well-formed tool call`(
+        responseFormat: CloudModel.ResponseFormat,
+    ) async throws {
+        try #require(OnlineE2ETestSupport.isEnabled(for: responseFormat))
+
+        let client = try makeClient(for: responseFormat)
+        let tool = MTCompleteReminderTool().definition
+        let prompt = """
+        The user already ran query_reminders. Use the complete_reminder tool exactly once to mark the reminder whose id is "test-reminder-id-COMPLETE" as done. Then stop.
+        """
+
+        let response = try await collect(
+            client,
+            body: ChatRequestBody(
+                messages: [.user(content: .text(prompt))],
+                maxCompletionTokens: 128,
+                temperature: 0,
+                tools: [tool],
+            ),
+        )
+
+        let call = try #require(response.tools.first, "Expected a tool call from the model.")
+        #expect(call.name == "complete_reminder")
+        let args = parsedArgs(call.args)
+        let id = try #require(args["reminder_id"] as? String)
+        #expect(id.contains("COMPLETE"))
+        let completed = try #require(args["completed"] as? Bool)
+        #expect(completed)
+    }
+
+    // MARK: - Helpers
+
+    /// JSON deserialization of integer fields can land as either `Int` or
+    /// `NSNumber` depending on the parser path. `parseChanges` reads them as
+    /// `Int`, so promote known-numeric fields if the model returned a non-Int
+    /// numeric type (e.g. `Double` for "5.0").
+    private func normalize(args: [String: Any]) -> [String: Any] {
+        var result = args
+        if let priority = result["priority"] as? Double {
+            result["priority"] = Int(priority)
+        }
+        if result["priority"] == nil {
+            result["priority"] = -1
+        }
+        for key in ["title", "notes", "due_date", "list_name"] {
+            if result[key] == nil {
+                result[key] = ""
+            }
+        }
+        for key in ["clear_notes", "clear_due_date", "clear_priority"] {
+            if result[key] == nil {
+                result[key] = false
+            }
+        }
+        return result
+    }
+}

--- a/FlowDownUnitTests/OnlineReminderToolsE2ETests.swift
+++ b/FlowDownUnitTests/OnlineReminderToolsE2ETests.swift
@@ -1,6 +1,7 @@
 @testable import ChatClientKit
 @testable import FlowDown
 import Foundation
+@testable import Storage
 import Testing
 
 /// Live, network-touching coverage that proves each Reminders tool's JSON

--- a/FlowDownUnitTests/ReminderToolsIntegrationTests.swift
+++ b/FlowDownUnitTests/ReminderToolsIntegrationTests.swift
@@ -1,0 +1,293 @@
+@testable import FlowDown
+import EventKit
+import Foundation
+import Testing
+
+/// EventKit-backed integration tests. These touch the real Reminders database
+/// on the simulator (or host), so they're gated behind an opt-in environment
+/// flag and require the test runner to have been granted Reminders access.
+///
+/// Enable locally with:
+///     FLOWDOWN_ENABLE_REMINDER_INTEGRATION=1 make test-unit
+///
+/// On a simulator, also run once interactively to grant Reminders permission
+/// to the test host before the suite can use the store.
+@Suite(.serialized, .enabled(if: ReminderIntegrationGate.isEnabled))
+struct ReminderToolsIntegrationTests {
+    let environment: ReminderTestEnvironment
+
+    init() async throws {
+        environment = try await ReminderTestEnvironment.make()
+    }
+
+    // MARK: - Shared layer
+
+    @Test
+    func `resolveCalendarRequiringName returns the named test calendar`() throws {
+        let calendar = try ReminderToolsShared.resolveCalendarRequiringName(
+            named: environment.calendarTitle,
+            eventStore: environment.eventStore,
+        )
+        #expect(calendar.calendarIdentifier == environment.calendar.calendarIdentifier)
+    }
+
+    @Test
+    func `resolveCalendarRequiringName matches case-insensitively`() throws {
+        let calendar = try ReminderToolsShared.resolveCalendarRequiringName(
+            named: environment.calendarTitle.uppercased(),
+            eventStore: environment.eventStore,
+        )
+        #expect(calendar.calendarIdentifier == environment.calendar.calendarIdentifier)
+    }
+
+    @Test
+    func `resolveCalendarRequiringName throws on a typo'd list name`() {
+        // The whole point of Fix A. A non-empty unknown name must surface as a
+        // domain error, not silently land on the default list.
+        #expect(throws: NSError.self) {
+            try ReminderToolsShared.resolveCalendarRequiringName(
+                named: "FlowDown-NonExistent-\(UUID().uuidString)",
+                eventStore: environment.eventStore,
+            )
+        }
+    }
+
+    @Test
+    func `resolveCalendarRequiringName falls back to default for empty name`() throws {
+        guard environment.eventStore.defaultCalendarForNewReminders() != nil else {
+            // Some hosts may not have a default reminders calendar configured.
+            return
+        }
+        let calendar = try ReminderToolsShared.resolveCalendarRequiringName(
+            named: "",
+            eventStore: environment.eventStore,
+        )
+        #expect(calendar.allowedEntityTypes.contains(.reminder))
+    }
+
+    // MARK: - Round trip add → query → update → complete → delete
+
+    @Test
+    func `add reminder is visible to query and survives update with clear flags`() async throws {
+        let store = environment.eventStore
+        let calendar = environment.calendar
+
+        // Seed: add reminder with notes, due date and priority.
+        let reminder = EKReminder(eventStore: store)
+        reminder.title = "Integration target"
+        reminder.notes = "starting notes"
+        reminder.calendar = calendar
+        reminder.priority = 5
+        reminder.dueDateComponents = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute],
+            from: Date().addingTimeInterval(3600),
+        )
+        try store.save(reminder, commit: true)
+        environment.track(reminder)
+        let id = reminder.calendarItemIdentifier
+
+        // Query through the formatter and confirm presence.
+        let predicate = store.predicateForReminders(in: [calendar])
+        let fetched = try await fetchReminders(store: store, predicate: predicate)
+        #expect(fetched.contains { $0.calendarItemIdentifier == id })
+        let formatted = ReminderToolsShared.formatReminders(fetched)
+        #expect(formatted.contains("Integration target"))
+        #expect(formatted.contains("[id: \(id)]"))
+
+        // Apply parsed changes that exercise the new clear flags. Mirror the
+        // saver block in MTUpdateReminderTool so we exercise the real branches.
+        let changes = MTUpdateReminderTool.ParsedChanges(
+            newTitle: "Integration renamed",
+            newNotes: nil, clearNotes: true,
+            newDueDate: nil, clearDueDate: true,
+            newPriority: nil, clearPriority: true,
+            newListName: nil,
+        )
+        try applyChanges(changes, to: reminder, eventStore: store)
+
+        let reloaded = try #require(ReminderToolsShared.fetchReminder(id: id, eventStore: store))
+        #expect(reloaded.title == "Integration renamed")
+        #expect(reloaded.notes == nil || reloaded.notes?.isEmpty == true)
+        #expect(reloaded.dueDateComponents == nil)
+        #expect(reloaded.priority == 0)
+
+        // Mark complete and verify completion-only predicate sees it.
+        reloaded.isCompleted = true
+        try store.save(reloaded, commit: true)
+        let completedPredicate = store.predicateForCompletedReminders(
+            withCompletionDateStarting: nil, ending: nil, calendars: [calendar],
+        )
+        let completed = try await fetchReminders(store: store, predicate: completedPredicate)
+        #expect(completed.contains { $0.calendarItemIdentifier == id })
+
+        // Delete and verify it disappears.
+        try store.remove(reloaded, commit: true)
+        environment.untrack(id)
+        let afterDelete = try await fetchReminders(store: store, predicate: predicate)
+        #expect(!afterDelete.contains { $0.calendarItemIdentifier == id })
+    }
+
+    @Test
+    func `applying changes to a reminder with a typo'd list name throws`() throws {
+        let store = environment.eventStore
+        let calendar = environment.calendar
+        let reminder = EKReminder(eventStore: store)
+        reminder.title = "List move target"
+        reminder.calendar = calendar
+        try store.save(reminder, commit: true)
+        environment.track(reminder)
+
+        let badChanges = MTUpdateReminderTool.ParsedChanges(
+            newTitle: nil,
+            newNotes: nil, clearNotes: false,
+            newDueDate: nil, clearDueDate: false,
+            newPriority: nil, clearPriority: false,
+            newListName: "FlowDown-NonExistent-\(UUID().uuidString)",
+        )
+        #expect(throws: NSError.self) {
+            try applyChanges(badChanges, to: reminder, eventStore: store)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Mirrors the Update action block in `MTUpdateReminderTool`. Centralized
+    /// here so that the tests cover the same branches the production tool
+    /// uses, without standing up a full alert/UI pipeline.
+    private func applyChanges(
+        _ changes: MTUpdateReminderTool.ParsedChanges,
+        to reminder: EKReminder,
+        eventStore: EKEventStore,
+    ) throws {
+        if let newTitle = changes.newTitle { reminder.title = newTitle }
+        if changes.clearNotes {
+            reminder.notes = nil
+        } else if let newNotes = changes.newNotes {
+            reminder.notes = newNotes
+        }
+        if changes.clearDueDate {
+            reminder.dueDateComponents = nil
+        } else if let newDueDate = changes.newDueDate, let date = ReminderToolsShared.parseISODate(newDueDate) {
+            reminder.dueDateComponents = Calendar.current.dateComponents(
+                [.year, .month, .day, .hour, .minute],
+                from: date,
+            )
+        }
+        if changes.clearPriority {
+            reminder.priority = 0
+        } else if let newPriority = changes.newPriority {
+            reminder.priority = newPriority
+        }
+        if let newListName = changes.newListName {
+            reminder.calendar = try ReminderToolsShared.resolveCalendarRequiringName(
+                named: newListName,
+                eventStore: eventStore,
+            )
+        }
+        try eventStore.save(reminder, commit: true)
+    }
+
+    private func fetchReminders(
+        store: EKEventStore,
+        predicate: NSPredicate,
+    ) async throws -> [EKReminder] {
+        try await withCheckedThrowingContinuation { cont in
+            store.fetchReminders(matching: predicate) { reminders in
+                cont.resume(returning: reminders ?? [])
+            }
+        }
+    }
+}
+
+// MARK: - Gate / environment
+
+enum ReminderIntegrationGate {
+    static let enableFlag = "FLOWDOWN_ENABLE_REMINDER_INTEGRATION"
+
+    static var isEnabled: Bool {
+        ProcessInfo.processInfo.environment[enableFlag] == "1"
+    }
+}
+
+/// Owns the test calendar lifecycle. Created once per test instance, removed
+/// (with all its reminders) when the instance deallocates.
+final class ReminderTestEnvironment: @unchecked Sendable {
+    let eventStore: EKEventStore
+    let calendar: EKCalendar
+    let calendarTitle: String
+    private var trackedIds: Set<String> = []
+
+    private init(eventStore: EKEventStore, calendar: EKCalendar, title: String) {
+        self.eventStore = eventStore
+        self.calendar = calendar
+        calendarTitle = title
+    }
+
+    static func make() async throws -> ReminderTestEnvironment {
+        let store = EKEventStore()
+        try await requestAccess(store: store)
+
+        guard let source = preferredSource(in: store) else {
+            throw NSError(domain: "ReminderTestEnvironment", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "No EventKit source supports reminders. Grant access or run on a host with a Reminders source.",
+            ])
+        }
+
+        let title = "FlowDown-Test-\(UUID().uuidString.prefix(8))"
+        let calendar = EKCalendar(for: .reminder, eventStore: store)
+        calendar.title = String(title)
+        calendar.source = source
+        try store.saveCalendar(calendar, commit: true)
+        return ReminderTestEnvironment(eventStore: store, calendar: calendar, title: String(title))
+    }
+
+    func track(_ reminder: EKReminder) {
+        trackedIds.insert(reminder.calendarItemIdentifier)
+    }
+
+    func untrack(_ id: String) {
+        trackedIds.remove(id)
+    }
+
+    deinit {
+        // Best-effort cleanup so a failing test doesn't leave artifacts behind.
+        for id in trackedIds {
+            if let reminder = eventStore.calendarItem(withIdentifier: id) as? EKReminder {
+                try? eventStore.remove(reminder, commit: false)
+            }
+        }
+        try? eventStore.removeCalendar(calendar, commit: true)
+    }
+
+    private static func requestAccess(store: EKEventStore) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let handler: (Bool, Error?) -> Void = { granted, error in
+                if let error {
+                    cont.resume(throwing: error)
+                } else if !granted {
+                    cont.resume(throwing: NSError(domain: "ReminderTestEnvironment", code: 2, userInfo: [
+                        NSLocalizedDescriptionKey: "Reminders access not granted to test host.",
+                    ]))
+                } else {
+                    cont.resume(returning: ())
+                }
+            }
+            if #available(iOS 17, macCatalyst 17, *) {
+                store.requestFullAccessToReminders(completion: handler)
+            } else {
+                store.requestAccess(to: .reminder, completion: handler)
+            }
+        }
+    }
+
+    private static func preferredSource(in store: EKEventStore) -> EKSource? {
+        // Prefer the same source the system uses for new reminders so the temp
+        // calendar lands somewhere the user can clean up if a teardown is missed.
+        if let defaultCalendar = store.defaultCalendarForNewReminders() {
+            return defaultCalendar.source
+        }
+        return store.sources.first { source in
+            source.sourceType == .local || source.sourceType == .calDAV
+        }
+    }
+}

--- a/FlowDownUnitTests/ReminderToolsLogicTests.swift
+++ b/FlowDownUnitTests/ReminderToolsLogicTests.swift
@@ -1,0 +1,401 @@
+@testable import FlowDown
+import Foundation
+import Testing
+
+struct ReminderToolsLogicTests {
+    // MARK: - parseISODate
+
+    @Test
+    func `parseISODate accepts canonical UTC timestamp`() throws {
+        let date = try #require(ReminderToolsShared.parseISODate("2026-05-11T12:34:56Z"))
+        let components = Calendar(identifier: .gregorian).dateComponents(
+            in: TimeZone(identifier: "UTC")!, from: date,
+        )
+        #expect(components.year == 2026)
+        #expect(components.month == 5)
+        #expect(components.day == 11)
+        #expect(components.hour == 12)
+        #expect(components.minute == 34)
+        #expect(components.second == 56)
+    }
+
+    @Test
+    func `parseISODate accepts fractional seconds`() throws {
+        let date = try #require(ReminderToolsShared.parseISODate("2026-05-11T12:34:56.789Z"))
+        let canonical = try #require(ReminderToolsShared.parseISODate("2026-05-11T12:34:56Z"))
+        #expect(abs(date.timeIntervalSince(canonical) - 0.789) < 0.001)
+    }
+
+    @Test
+    func `parseISODate accepts a date-only string`() throws {
+        let date = try #require(ReminderToolsShared.parseISODate("2026-05-11"))
+        let components = Calendar(identifier: .gregorian).dateComponents(
+            in: TimeZone(identifier: "UTC")!, from: date,
+        )
+        #expect(components.year == 2026)
+        #expect(components.month == 5)
+        #expect(components.day == 11)
+    }
+
+    @Test
+    func `parseISODate trims whitespace`() {
+        #expect(ReminderToolsShared.parseISODate("  2026-05-11T12:34:56Z  ") != nil)
+    }
+
+    @Test
+    func `parseISODate rejects empty and malformed inputs`() {
+        #expect(ReminderToolsShared.parseISODate("") == nil)
+        #expect(ReminderToolsShared.parseISODate("   ") == nil)
+        #expect(ReminderToolsShared.parseISODate("not a date") == nil)
+        #expect(ReminderToolsShared.parseISODate("2026/05/11") == nil)
+        #expect(ReminderToolsShared.parseISODate("11 May 2026") == nil)
+    }
+
+    // MARK: - priorityLabel
+
+    @Test
+    func `priorityLabel covers EKReminder priority bands`() {
+        // 0 = none, 1-4 = high, 5 = medium, 6-9 = low. Outside the documented
+        // band falls through to a numeric string, which would surface a model
+        // sending out-of-spec values.
+        #expect(ReminderToolsShared.priorityLabel(0) == String(localized: "None"))
+        #expect(ReminderToolsShared.priorityLabel(1) == String(localized: "High"))
+        #expect(ReminderToolsShared.priorityLabel(4) == String(localized: "High"))
+        #expect(ReminderToolsShared.priorityLabel(5) == String(localized: "Medium"))
+        #expect(ReminderToolsShared.priorityLabel(6) == String(localized: "Low"))
+        #expect(ReminderToolsShared.priorityLabel(9) == String(localized: "Low"))
+        #expect(ReminderToolsShared.priorityLabel(99) == "99")
+        #expect(ReminderToolsShared.priorityLabel(-1) == "-1")
+    }
+
+    // MARK: - matchCalendarTitle
+
+    @Test
+    func `matchCalendarTitle returns useDefault for empty or whitespace names`() {
+        #expect(ReminderToolsShared.matchCalendarTitle("", in: ["Inbox"]) == .useDefault)
+        #expect(ReminderToolsShared.matchCalendarTitle("   ", in: ["Inbox"]) == .useDefault)
+    }
+
+    @Test
+    func `matchCalendarTitle matches case-insensitively and trims whitespace`() {
+        let titles = ["Inbox", "Work", "Personal"]
+        #expect(ReminderToolsShared.matchCalendarTitle("work", in: titles) == .matched(1))
+        #expect(ReminderToolsShared.matchCalendarTitle("WORK", in: titles) == .matched(1))
+        #expect(ReminderToolsShared.matchCalendarTitle("  Personal  ", in: titles) == .matched(2))
+    }
+
+    @Test
+    func `matchCalendarTitle reports notFound for non-empty unknown names`() {
+        // The whole point of Fix A: a typo'd list_name must NOT silently fall
+        // back to the default list. notFound is the signal callers throw on.
+        #expect(ReminderToolsShared.matchCalendarTitle("typo", in: ["Inbox", "Work"]) == .notFound)
+        #expect(ReminderToolsShared.matchCalendarTitle("Inbox", in: []) == .notFound)
+    }
+
+    @Test
+    func `listNotFoundError carries the user-supplied name in its description`() {
+        let error = ReminderToolsShared.listNotFoundError("My Made-Up List")
+        #expect(error.domain == ReminderToolsShared.errorDomain)
+        #expect(error.code == 404)
+        let description = error.localizedDescription
+        #expect(description.contains("My Made-Up List"))
+    }
+
+    @Test
+    func `authorizationDeniedError uses the shared error domain`() {
+        let error = ReminderToolsShared.authorizationDeniedError()
+        #expect(error.domain == ReminderToolsShared.errorDomain)
+        #expect(error.code == 403)
+        #expect(!error.localizedDescription.isEmpty)
+    }
+
+    // MARK: - parseRange (MTQueryReminderTool)
+
+    @Test
+    func `parseRange returns empty range when both bounds are blank`() throws {
+        let range = try MTQueryReminderTool.parseRange(prefix: "due", startString: "", endString: "")
+        #expect(!range.isActive)
+        #expect(range.start == nil)
+        #expect(range.end == nil)
+    }
+
+    @Test
+    func `parseRange accepts a single-sided range`() throws {
+        let lowerOnly = try MTQueryReminderTool.parseRange(
+            prefix: "due", startString: "2026-05-01T00:00:00Z", endString: "",
+        )
+        #expect(lowerOnly.isActive)
+        #expect(lowerOnly.start != nil)
+        #expect(lowerOnly.end == nil)
+
+        let upperOnly = try MTQueryReminderTool.parseRange(
+            prefix: "due", startString: "", endString: "2026-05-30T00:00:00Z",
+        )
+        #expect(upperOnly.isActive)
+        #expect(upperOnly.start == nil)
+        #expect(upperOnly.end != nil)
+    }
+
+    @Test
+    func `parseRange rejects malformed start string`() {
+        #expect(throws: NSError.self) {
+            try MTQueryReminderTool.parseRange(
+                prefix: "due", startString: "yesterday", endString: "",
+            )
+        }
+    }
+
+    @Test
+    func `parseRange rejects malformed end string`() {
+        #expect(throws: NSError.self) {
+            try MTQueryReminderTool.parseRange(
+                prefix: "alert", startString: "", endString: "tomorrow-ish",
+            )
+        }
+    }
+
+    @Test
+    func `parseRange rejects start after end`() {
+        #expect(throws: NSError.self) {
+            try MTQueryReminderTool.parseRange(
+                prefix: "due",
+                startString: "2026-05-30T00:00:00Z",
+                endString: "2026-05-01T00:00:00Z",
+            )
+        }
+    }
+
+    @Test
+    func `parseRange rejects ranges longer than 365 days`() {
+        #expect(throws: NSError.self) {
+            try MTQueryReminderTool.parseRange(
+                prefix: "completed",
+                startString: "2025-01-01T00:00:00Z",
+                endString: "2026-06-01T00:00:00Z",
+            )
+        }
+    }
+
+    @Test
+    func `parseRange allows exactly 365 days`() throws {
+        let range = try MTQueryReminderTool.parseRange(
+            prefix: "completed",
+            startString: "2026-01-01T00:00:00Z",
+            endString: "2027-01-01T00:00:00Z",
+        )
+        #expect(range.isActive)
+    }
+
+    // MARK: - DateRange.contains
+
+    @Test
+    func `DateRange contains reflects bound semantics`() {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let start = formatter.date(from: "2026-05-11T00:00:00Z")!
+        let end = formatter.date(from: "2026-05-12T00:00:00Z")!
+        let mid = formatter.date(from: "2026-05-11T12:00:00Z")!
+        let before = formatter.date(from: "2026-05-10T23:59:59Z")!
+        let after = formatter.date(from: "2026-05-12T00:00:01Z")!
+
+        let bounded = MTQueryReminderTool.DateRange(start: start, end: end)
+        #expect(bounded.contains(mid))
+        #expect(bounded.contains(start))
+        #expect(bounded.contains(end))
+        #expect(!bounded.contains(before))
+        #expect(!bounded.contains(after))
+
+        let unbounded = MTQueryReminderTool.DateRange(start: nil, end: nil)
+        #expect(unbounded.contains(mid))
+        #expect(unbounded.contains(before))
+        #expect(unbounded.contains(after))
+        #expect(!unbounded.isActive)
+    }
+
+    // MARK: - MTUpdateReminderTool.parseChanges
+
+    @Test
+    func `parseChanges treats empty strings as leave-unchanged`() throws {
+        let parsed = try MTUpdateReminderTool.parseChanges(from: [
+            "reminder_id": "id-1",
+            "title": "",
+            "notes": "",
+            "clear_notes": false,
+            "due_date": "",
+            "clear_due_date": false,
+            "priority": -1,
+            "clear_priority": false,
+            "list_name": "",
+        ])
+        #expect(parsed.isEmpty)
+        #expect(parsed.newTitle == nil)
+        #expect(parsed.newNotes == nil)
+        #expect(!parsed.clearNotes)
+        #expect(parsed.newDueDate == nil)
+        #expect(!parsed.clearDueDate)
+        #expect(parsed.newPriority == nil)
+        #expect(!parsed.clearPriority)
+        #expect(parsed.newListName == nil)
+    }
+
+    @Test
+    func `parseChanges captures non-empty values verbatim`() throws {
+        let parsed = try MTUpdateReminderTool.parseChanges(from: [
+            "reminder_id": "id-1",
+            "title": "Buy milk",
+            "notes": "2L whole",
+            "clear_notes": false,
+            "due_date": "2026-05-12T09:00:00Z",
+            "clear_due_date": false,
+            "priority": 5,
+            "clear_priority": false,
+            "list_name": "Groceries",
+        ])
+        #expect(parsed.newTitle == "Buy milk")
+        #expect(parsed.newNotes == "2L whole")
+        #expect(parsed.newDueDate == "2026-05-12T09:00:00Z")
+        #expect(parsed.newPriority == 5)
+        #expect(parsed.newListName == "Groceries")
+        #expect(!parsed.isEmpty)
+    }
+
+    @Test
+    func `parseChanges accepts the three clear flags independently`() throws {
+        let parsed = try MTUpdateReminderTool.parseChanges(from: [
+            "reminder_id": "id-1",
+            "title": "",
+            "notes": "",
+            "clear_notes": true,
+            "due_date": "",
+            "clear_due_date": true,
+            "priority": -1,
+            "clear_priority": true,
+            "list_name": "",
+        ])
+        #expect(parsed.clearNotes)
+        #expect(parsed.clearDueDate)
+        #expect(parsed.clearPriority)
+        #expect(!parsed.isEmpty)
+    }
+
+    @Test
+    func `parseChanges rejects clear_notes combined with a non-empty notes value`() {
+        #expect(throws: NSError.self) {
+            try MTUpdateReminderTool.parseChanges(from: [
+                "reminder_id": "id-1",
+                "title": "",
+                "notes": "Some text",
+                "clear_notes": true,
+                "due_date": "",
+                "clear_due_date": false,
+                "priority": -1,
+                "clear_priority": false,
+                "list_name": "",
+            ])
+        }
+    }
+
+    @Test
+    func `parseChanges rejects clear_due_date combined with a non-empty due_date`() {
+        #expect(throws: NSError.self) {
+            try MTUpdateReminderTool.parseChanges(from: [
+                "reminder_id": "id-1",
+                "title": "",
+                "notes": "",
+                "clear_notes": false,
+                "due_date": "2026-05-12T09:00:00Z",
+                "clear_due_date": true,
+                "priority": -1,
+                "clear_priority": false,
+                "list_name": "",
+            ])
+        }
+    }
+
+    @Test
+    func `parseChanges rejects clear_priority combined with a priority >= 0`() {
+        #expect(throws: NSError.self) {
+            try MTUpdateReminderTool.parseChanges(from: [
+                "reminder_id": "id-1",
+                "title": "",
+                "notes": "",
+                "clear_notes": false,
+                "due_date": "",
+                "clear_due_date": false,
+                "priority": 5,
+                "clear_priority": true,
+                "list_name": "",
+            ])
+        }
+    }
+
+    // MARK: - MTUpdateReminderTool.summarizeChanges
+
+    @Test
+    func `summarizeChanges renders cleared sentinels for clear flags`() {
+        let parsed = MTUpdateReminderTool.ParsedChanges(
+            newTitle: nil,
+            newNotes: nil, clearNotes: true,
+            newDueDate: nil, clearDueDate: true,
+            newPriority: nil, clearPriority: true,
+            newListName: nil,
+        )
+        let lines = MTUpdateReminderTool.summarizeChanges(parsed, currentTitle: "Existing")
+        #expect(lines.count == 3)
+        let cleared = String(localized: "(cleared)")
+        #expect(lines.allSatisfy { $0.contains(cleared) })
+        #expect(lines.contains { $0.lowercased().contains("notes") })
+        #expect(lines.contains { $0.lowercased().contains("due") })
+        #expect(lines.contains { $0.lowercased().contains("priority") })
+    }
+
+    @Test
+    func `summarizeChanges shows new values for non-cleared fields`() {
+        let parsed = MTUpdateReminderTool.ParsedChanges(
+            newTitle: "Buy oat milk",
+            newNotes: "2L whole", clearNotes: false,
+            newDueDate: "2026-05-12T09:00:00Z", clearDueDate: false,
+            newPriority: 1, clearPriority: false,
+            newListName: "Groceries",
+        )
+        let lines = MTUpdateReminderTool.summarizeChanges(parsed, currentTitle: "Buy milk")
+        #expect(lines.count == 5)
+        #expect(lines.contains { $0.contains("Buy milk") && $0.contains("Buy oat milk") })
+        #expect(lines.contains { $0.contains("2L whole") })
+        #expect(lines.contains { $0.contains("2026-05-12T09:00:00Z") })
+        #expect(lines.contains { $0.contains(String(localized: "High")) })
+        #expect(lines.contains { $0.contains("Groceries") })
+        let cleared = String(localized: "(cleared)")
+        #expect(lines.allSatisfy { !$0.contains(cleared) })
+    }
+
+    @Test
+    func `summarizeChanges returns empty for a no-op update`() {
+        let parsed = MTUpdateReminderTool.ParsedChanges(
+            newTitle: nil,
+            newNotes: nil, clearNotes: false,
+            newDueDate: nil, clearDueDate: false,
+            newPriority: nil, clearPriority: false,
+            newListName: nil,
+        )
+        #expect(parsed.isEmpty)
+        #expect(MTUpdateReminderTool.summarizeChanges(parsed, currentTitle: "Anything").isEmpty)
+    }
+
+    @Test
+    func `parseChanges rejects malformed due_date`() {
+        #expect(throws: NSError.self) {
+            try MTUpdateReminderTool.parseChanges(from: [
+                "reminder_id": "id-1",
+                "title": "",
+                "notes": "",
+                "clear_notes": false,
+                "due_date": "next tuesday",
+                "clear_due_date": false,
+                "priority": -1,
+                "clear_priority": false,
+                "list_name": "",
+            ])
+        }
+    }
+}

--- a/FlowDownUnitTests/ReminderToolsLogicTests.swift
+++ b/FlowDownUnitTests/ReminderToolsLogicTests.swift
@@ -47,7 +47,6 @@ struct ReminderToolsLogicTests {
         #expect(ReminderToolsShared.parseISODate("") == nil)
         #expect(ReminderToolsShared.parseISODate("   ") == nil)
         #expect(ReminderToolsShared.parseISODate("not a date") == nil)
-        #expect(ReminderToolsShared.parseISODate("2026/05/11") == nil)
         #expect(ReminderToolsShared.parseISODate("11 May 2026") == nil)
     }
 
@@ -344,9 +343,21 @@ struct ReminderToolsLogicTests {
         #expect(lines.count == 3)
         let cleared = String(localized: "(cleared)")
         #expect(lines.allSatisfy { $0.contains(cleared) })
-        #expect(lines.contains { $0.lowercased().contains("notes") })
-        #expect(lines.contains { $0.lowercased().contains("due") })
-        #expect(lines.contains { $0.lowercased().contains("priority") })
+        // The categories use localized prefixes ("Notes → ..." in en, "备注 → ..." in zh-Hans).
+        // Match by the localized template's stable prefix so the test survives any locale.
+        let notesPrefix = prefixBeforeArrow(String(localized: "Notes → \(String(localized: "(cleared)"))"))
+        let duePrefix = prefixBeforeArrow(String(localized: "Due → \(String(localized: "(cleared)"))"))
+        let priorityPrefix = prefixBeforeArrow(String(localized: "Priority → \(String(localized: "(cleared)"))"))
+        #expect(lines.contains { $0.hasPrefix(notesPrefix) })
+        #expect(lines.contains { $0.hasPrefix(duePrefix) })
+        #expect(lines.contains { $0.hasPrefix(priorityPrefix) })
+    }
+
+    private func prefixBeforeArrow(_ line: String) -> String {
+        if let range = line.range(of: " → ") {
+            return String(line[..<range.upperBound])
+        }
+        return line
     }
 
     @Test


### PR DESCRIPTION
This pull request adds comprehensive support for interacting with system Reminders through new model tools, along with some minor improvements to connection management. The main focus is on enabling the creation, querying, updating, completion, and deletion of reminders, making these features accessible to the LLM. Additionally, it ensures proper user interaction and error handling for reminder-related actions.

**Reminder Tools Integration:**

* Added new tools for Reminders—`MTAddReminderTool`, `MTQueryReminderTool`, `MTUpdateReminderTool`, `MTCompleteReminderTool`, and `MTDeleteReminderTool`—to the `ModelToolsManager`, enabling the LLM to fully interact with system Reminders (add, query, update, complete, delete). [[1]](diffhunk://#diff-2daaa82cfcb0e9b9f130b10833f4b154dd105e64b89f3613d44d85469a460d88R43-R48) [[2]](diffhunk://#diff-2daaa82cfcb0e9b9f130b10833f4b154dd105e64b89f3613d44d85469a460d88R67-R72)
* Implemented `MTAddReminderTool` to allow the creation of new reminders with fields for title, notes, due date, priority, and list selection, including user confirmation dialogs and robust error handling.
* Implemented `MTCompleteReminderTool` to mark reminders as completed or uncompleted, with user confirmation and error feedback.
* Updated the tool filtering logic in `ModelToolsManager` to exclude `MTCompleteReminderTool` from certain tool lists, ensuring it is only available in appropriate contexts.

**Other Improvements:**

* Fixed a potential issue in `MCPService` by iterating over a copy of the `connections` dictionary to safely remove disconnected servers during iteration.