### PR TITLE
Add LookInside debug server

### DIFF
--- a/FlowDown.xcodeproj/project.pbxproj
+++ b/FlowDown.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		50F6E0002F00A0B500123456 /* FlowDownModelExchange in Frameworks */ = {isa = PBXBuildFile; productRef = 50F6E0012F00A0B500123456 /* FlowDownModelExchange */; };
 		50FBFC6C2DEA2E5400098EC4 /* XMLCoder in Frameworks */ = {isa = PBXBuildFile; productRef = 50FBFC6B2DEA2E5400098EC4 /* XMLCoder */; };
 		86B4FDC22E1190C000C6DC8F /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = 86B4FDC12E1190C000C6DC8F /* MCP */; };
+		E7C99B17D5D676F620653AB0 /* LookInsideServer in Frameworks */ = {isa = PBXBuildFile; productRef = FA30BB662ED329E2DCF59D4D /* LookInsideServer */; };
 		ED16359C2D5C5BDA0081BD0B /* ChatClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = ED16359B2D5C5BDA0081BD0B /* ChatClientKit */; };
 		EDF9A13E2D67788A001D183C /* Respring in Frameworks */ = {isa = PBXBuildFile; productRef = EDF9A13D2D67788A001D183C /* Respring */; };
 /* End PBXBuildFile section */
@@ -193,6 +194,8 @@
 		};
 		50D757BB2EC10A4400AEC087 /* FlowDownUnitTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = FlowDownUnitTests;
 			sourceTree = "<group>";
 		};
@@ -241,6 +244,7 @@
 				5081A0142D6DBBBA0079ECBE /* RunestoneEditor in Frameworks */,
 				50AE75802EF436FC00D2C845 /* OrderedCollections in Frameworks */,
 				50B514782D23157A0092284C /* SnapKit in Frameworks */,
+				E7C99B17D5D676F620653AB0 /* LookInsideServer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -377,6 +381,7 @@
 				50AE757D2EF436FC00D2C845 /* Collections */,
 				50AE757F2EF436FC00D2C845 /* OrderedCollections */,
 				509038612FB0EB8500110DDB /* iCalendarParser */,
+				FA30BB662ED329E2DCF59D4D /* LookInsideServer */,
 			);
 			productName = FlowDown;
 			productReference = 503498BD2D23053D004672BD /* FlowDown.app */;
@@ -398,8 +403,6 @@
 				50433EC42F0D6A8200445939 /* FlowDownWidgets */,
 			);
 			name = FlowDownWidgetsExtension;
-			packageProductDependencies = (
-			);
 			productName = FlowDownWidgetsExtension;
 			productReference = 50433EBF2F0D6A8200445939 /* FlowDownWidgetsExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -496,8 +499,10 @@
 				506373A42EC0DC7900C8A9FB /* XCRemoteSwiftPackageReference "ColorfulX" */,
 				50AE757C2EF436FC00D2C845 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				509038602FB0EB8500110DDB /* XCRemoteSwiftPackageReference "iCalendarParser" */,
+				36DBADE12AFFAEDBD3909D03 /* XCRemoteSwiftPackageReference "LookInside-Release" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 503498BE2D23053D004672BD /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -770,6 +775,10 @@
 				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_USER_SELECTED_FILES = readwrite;
+				EXCLUDED_SOURCE_FILE_NAMES = (
+					"$(inherited)",
+					"LookInsideServer*",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "FlowDown/Resources/InfoPlist/Info-iOS.plist";
 				"INFOPLIST_FILE[sdk=macosx*]" = "FlowDown/Resources/InfoPlist/Info-Catalyst.plist";
@@ -1120,6 +1129,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		36DBADE12AFFAEDBD3909D03 /* XCRemoteSwiftPackageReference "LookInside-Release" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/LookInsideApp/LookInside-Release.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.2;
+			};
+		};
 		50014D7B2D8A98F900C10932 /* XCRemoteSwiftPackageReference "ScrubberKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Lakr233/ScrubberKit";
@@ -1460,6 +1477,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = EDF9A13C2D67788A001D183C /* XCRemoteSwiftPackageReference "Respring" */;
 			productName = Respring;
+		};
+		FA30BB662ED329E2DCF59D4D /* LookInsideServer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36DBADE12AFFAEDBD3909D03 /* XCRemoteSwiftPackageReference "LookInside-Release" */;
+			productName = LookInsideServer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ The decoupled libraries used to build, or extracted from FlowDown are listed bel
 
 Please note that while the code is open source, the FlowDown name, icon, and artwork are proprietary. For commercial licensing inquiries, please contact us.
 
----
-
-© 2025-2026 FlowDown Team (@Lakr233) All Rights Reserved.
 ## Sponsor
 
 [LookInside](https://lookinside-app.com/) helps you inspect a running iOS or macOS app UI from your Mac.
+
+---
+
+© 2025-2026 FlowDown Team (@Lakr233) All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ Please note that while the code is open source, the FlowDown name, icon, and art
 ---
 
 © 2025-2026 FlowDown Team (@Lakr233) All Rights Reserved.
+## Sponsor
+
+[LookInside](https://lookinside-app.com/) helps you inspect a running iOS or macOS app UI from your Mac.


### PR DESCRIPTION
## What changed

- Add the LookInside-Release Swift package and link the LookInsideServer product into the app target.
- Exclude LookInsideServer from Release builds with `EXCLUDED_SOURCE_FILE_NAMES = $(inherited) LookInsideServer*`.
- Add the LookInside sponsor block to the root README.

## Validation

- Debug build passes.
- Release build passes.
- Debug artifact contains LookInsideServer.
- Release artifact excludes LookInsideServer.
