### PR TITLE
Fix Blank Fenced Code Blocks

### DIFF
--- a/FlowDown/Interface/MessageListView/Components/AiMessageView.swift
+++ b/FlowDown/Interface/MessageListView/Components/AiMessageView.swift
@@ -10,10 +10,14 @@ import UIKit
 
 final class AiMessageView: MessageListRowView {
     private(set) lazy var markdownView: MarkdownTextView = .init().with {
-        $0.throttleInterval = 1 / 60
+        // Assistant updates are coalesced by this row's display link. Keeping
+        // MarkdownView immediate gives every rebuild a known, nonzero width.
+        $0.throttleInterval = nil
     }
 
     private var representedMessageID: Message.ID?
+    private var pendingPackage: MarkdownContent?
+    private var displayLink: CADisplayLink?
 
     var linkTapHandler: ((LinkPayload, NSRange, CGPoint) -> Void)? {
         get { markdownView.linkHandler }
@@ -35,25 +39,38 @@ final class AiMessageView: MessageListRowView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        displayLink?.invalidate()
+    }
+
     private func configureSubviews() {
         contentView.addSubview(markdownView)
     }
 
-    /// Puts the message content on screen. The first fill for a message is
-    /// applied synchronously so a freshly (re)used row never renders blank;
-    /// subsequent updates to the same message stream through the throttled
-    /// path and update the visible content in place.
+    /// Builds a fenced-code view only after this row has a usable width.
+    /// Streaming packages are coalesced to the display cadence so a code view
+    /// is never torn down and rebuilt several times in one rendered frame.
     func setMarkdownPackage(_ package: MarkdownContent, for messageID: Message.ID) {
-        if representedMessageID == messageID {
-            markdownView.setContent(package)
+        let isNewMessage = representedMessageID != messageID
+        representedMessageID = messageID
+        pendingPackage = package
+
+        if isNewMessage {
+            displayLink?.invalidate()
+            displayLink = nil
+            setNeedsLayout()
+            layoutIfNeeded()
+            flushPendingPackageIfPossible()
         } else {
-            representedMessageID = messageID
-            markdownView.setContentImmediately(package)
+            schedulePendingPackage()
         }
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        displayLink?.invalidate()
+        displayLink = nil
+        pendingPackage = nil
         representedMessageID = nil
         // Parked cells still receive CodeHighlighter notifications which trigger
         // a full document rebuild; empty their content so that rebuild is free.
@@ -64,5 +81,46 @@ final class AiMessageView: MessageListRowView {
         super.layoutSubviews()
         markdownView.frame = contentView.bounds
         markdownView.trackedScrollView = nearestScrollView
+
+        // Initial conversation loads configure a row before its first visible
+        // layout. There is no display link yet, so finish that package here.
+        if displayLink == nil {
+            flushPendingPackageIfPossible()
+        }
+    }
+
+    private func schedulePendingPackage() {
+        guard pendingPackage != nil else { return }
+        guard window != nil else {
+            setNeedsLayout()
+            return
+        }
+        guard displayLink == nil else { return }
+
+        let displayLink = CADisplayLink(target: self, selector: #selector(flushPendingPackageOnDisplayLink))
+        displayLink.add(to: .main, forMode: .common)
+        self.displayLink = displayLink
+    }
+
+    @objc private func flushPendingPackageOnDisplayLink() {
+        flushPendingPackageIfPossible()
+        guard pendingPackage == nil else { return }
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+
+    private func flushPendingPackageIfPossible() {
+        guard let package = pendingPackage, contentView.bounds.width > 0 else { return }
+        pendingPackage = nil
+
+        UIView.performWithoutAnimation {
+            self.markdownView.frame = self.contentView.bounds
+            self.markdownView.trackedScrollView = self.nearestScrollView
+            self.markdownView.setContentImmediately(package)
+            self.markdownView.textLabelView.preferredMaxLayoutWidth = self.contentView.bounds.width
+            self.markdownView.textLabelView.reloadTextLayout()
+            self.markdownView.setNeedsLayout()
+            self.markdownView.layoutIfNeeded()
+        }
     }
 }

--- a/FlowDown/Interface/MessageListView/MessageListView.swift
+++ b/FlowDown/Interface/MessageListView/MessageListView.swift
@@ -121,10 +121,10 @@ final class MessageListView: UIView {
         listView.contentInsetAdjustmentBehavior = .never
         listView.automaticallyAdjustsScrollIndicatorInsets = false
         listView.showsHorizontalScrollIndicator = false
-        // Rows trail the scroll on springs; the content offset itself is
-        // untouched, so the auto-scroll-to-bottom math is unaffected.
-        // Same tuning as AirBuild, by feel.
-        listView.rowAnimator = ListBouncyAnimator(damping: 0.975, frequency: 25.0)
+        // Markdown fenced-code views are positioned during row layout. Do not
+        // displace rows with a per-frame animator: it can show a code view
+        // after the source text layout has changed, leaving it blank until a
+        // later window resize triggers a full layout pass.
         addSubview(listView)
         listView.snp.makeConstraints { make in
             make.edges.equalToSuperview()


### PR DESCRIPTION
## Summary
- coalesce assistant markdown streaming updates on a display link
- defer markdown code-context construction until the message row has a nonzero width
- remove row displacement that can desynchronize fenced-code subviews from their source text layout

Fixes #287.

## Testing
- Published and installed the Mac Catalyst verification build from the fork; both arm64 and x86_64 archives completed successfully.