### PR TITLE
fix: Prevent message cell deformation during keyboard dismissal

### DIFF
--- a/FlowDown/Interface/ChatView/ChatView.swift
+++ b/FlowDown/Interface/ChatView/ChatView.swift
@@ -89,11 +89,14 @@ class ChatView: UIView {
 
         editor.handlerColor = handlerColor
         editor.delegate = self
+        #if !targetEnvironment(macCatalyst)
+            keyboardLayoutGuide.usesBottomSafeArea = false
+        #endif
         editor.snp.makeConstraints { make in
             #if targetEnvironment(macCatalyst)
                 make.bottom.equalToSuperview()
             #else
-                make.bottom.equalTo(safeAreaLayoutGuide)
+                make.bottom.equalTo(keyboardLayoutGuide.snp.top)
             #endif
             make.centerX.equalToSuperview()
             make.width.lessThanOrEqualTo(750)

--- a/FlowDown/Interface/MainController/MainController+Content.swift
+++ b/FlowDown/Interface/MainController/MainController+Content.swift
@@ -48,10 +48,8 @@ extension MainController {
         }
 
         #if !targetEnvironment(macCatalyst)
-            contentView.keyboardLayoutGuide.usesBottomSafeArea = false
             contentView.contentView.snp.remakeConstraints { make in
-                make.left.right.top.equalToSuperview()
-                make.bottom.equalTo(contentView.keyboardLayoutGuide.snp.top)
+                make.edges.equalToSuperview()
             }
         #endif
 

--- a/FlowDownUnitTests/ChatKeyboardLayoutTests.swift
+++ b/FlowDownUnitTests/ChatKeyboardLayoutTests.swift
@@ -1,4 +1,5 @@
 @testable import FlowDown
+import Storage
 import Testing
 import UIKit
 
@@ -88,4 +89,58 @@ struct ChatKeyboardLayoutTests {
                 && constraint.secondAttribute == secondAttribute
         }
     }
+}
+
+extension ChatKeyboardLayoutTests {
+    #if !targetEnvironment(macCatalyst)
+        /// The maintainer's concern on #289 is that pinning only the editor to the keyboard
+        /// guide, while the list fills the whole view, would put the bottom of the list under
+        /// the editor and make the last message unreachable.
+        ///
+        /// It does not, because `updateCurrentMessageListInsets()` derives the list's bottom
+        /// content inset from the editor's frame on every layout pass. This asserts that
+        /// invariant directly: the list's usable content region must always stop at or above
+        /// the top of the editor, at any view height.
+        @Test
+        @MainActor
+        func `message list content stays clear of the editor at any height`() async throws {
+            try await FlowDownTestContext.shared.ensureBootstrappedEnvironment()
+            let conversation = sdb.conversationMake { conversation in
+                conversation.update(\.title, to: "Keyboard Layout \(UUID().uuidString.prefix(8))")
+            }
+            defer { ConversationManager.shared.deleteConversation(identifier: conversation.id) }
+
+            let chatView = ChatView()
+            chatView.conversationIdentifier = conversation.id
+
+            // keyboardLayoutGuide only resolves for a view inside a window.
+            let window = UIWindow(frame: .init(x: 0, y: 0, width: 390, height: 640))
+            window.addSubview(chatView)
+            window.makeKeyAndVisible()
+
+            for height in [640.0, 800.0, 1000.0] as [CGFloat] {
+                window.frame = .init(x: 0, y: 0, width: 390, height: height)
+                chatView.frame = window.bounds
+                chatView.setNeedsLayout()
+                chatView.layoutIfNeeded()
+
+                guard let listView = chatView.currentMessageListView else {
+                    #expect(Bool(false), "expected a message list view at height \(height)")
+                    continue
+                }
+
+                let editorTop = min(chatView.editor.frame.minY, chatView.editorBackgroundView.frame.minY)
+                let contentBottom = chatView.bounds.height - listView.contentSafeAreaInsets.bottom
+
+                #expect(
+                    listView.contentSafeAreaInsets.bottom > 0,
+                    "list must reserve room for the editor at height \(height)",
+                )
+                #expect(
+                    contentBottom <= editorTop,
+                    "content region (\(contentBottom)) must end at or above the editor top (\(editorTop)) at height \(height)",
+                )
+            }
+        }
+    #endif
 }

--- a/FlowDownUnitTests/ChatKeyboardLayoutTests.swift
+++ b/FlowDownUnitTests/ChatKeyboardLayoutTests.swift
@@ -1,0 +1,91 @@
+@testable import FlowDown
+import Testing
+import UIKit
+
+struct ChatKeyboardLayoutTests {
+    #if !targetEnvironment(macCatalyst)
+        @Test
+        @MainActor
+        func `main controller keeps the chat host at full height`() {
+            let controller = MainController()
+            controller.loadViewIfNeeded()
+
+            #expect(
+                hasConstraint(
+                    in: controller.contentView,
+                    controller.contentView.contentView,
+                    .bottom,
+                    controller.contentView,
+                    .bottom,
+                ),
+            )
+            #expect(
+                !hasConstraint(
+                    in: controller.contentView,
+                    controller.contentView.contentView,
+                    .bottom,
+                    controller.contentView.keyboardLayoutGuide,
+                    .top,
+                ),
+            )
+            #expect(
+                hasConstraint(
+                    in: controller.contentView.contentView,
+                    controller.chatView,
+                    .bottom,
+                    controller.contentView.contentView,
+                    .bottom,
+                ),
+            )
+        }
+
+        @Test
+        @MainActor
+        func `chat editor follows the keyboard layout guide`() {
+            let chatView = ChatView()
+
+            #expect(!chatView.keyboardLayoutGuide.usesBottomSafeArea)
+            #expect(
+                hasConstraint(
+                    in: chatView,
+                    chatView.editor,
+                    .bottom,
+                    chatView.keyboardLayoutGuide,
+                    .top,
+                ),
+            )
+        }
+    #else
+        @Test
+        @MainActor
+        func `catalyst chat editor remains anchored to the chat view bottom`() {
+            let chatView = ChatView()
+
+            #expect(
+                hasConstraint(
+                    in: chatView,
+                    chatView.editor,
+                    .bottom,
+                    chatView,
+                    .bottom,
+                ),
+            )
+        }
+    #endif
+
+    private func hasConstraint(
+        in owner: UIView,
+        _ firstItem: AnyObject,
+        _ firstAttribute: NSLayoutConstraint.Attribute,
+        _ secondItem: AnyObject,
+        _ secondAttribute: NSLayoutConstraint.Attribute,
+    ) -> Bool {
+        owner.constraints.contains { constraint in
+            constraint.isActive
+                && (constraint.firstItem as AnyObject?) === firstItem
+                && constraint.firstAttribute == firstAttribute
+                && (constraint.secondItem as AnyObject?) === secondItem
+                && constraint.secondAttribute == secondAttribute
+        }
+    }
+}


### PR DESCRIPTION
On iOS 26, dismissing the keyboard when a message cell is close to entering the visible area can make the off-screen cell appear to stretch and move downward from the top. The current iOS wiring constrains the entire chat content host to `contentView.keyboardLayoutGuide`, so a keyboard transition animates the bounds of the title, message list, and editor together. That forces ListViewKit to relayout newly visible rows inside UIKit's keyboard animation even though only the editor and the list's usable bottom edge need to move. The issue is limited to iPhone and iPad; Catalyst behavior must remain unchanged.

## Summary

Keep `contentView.contentView` pinned to the full iOS content bounds in `MainController+Content.swift` rather than shrinking it to the keyboard layout guide. Move keyboard avoidance into `ChatView.swift`: configure the chat view's keyboard layout guide and constrain the editor's bottom to the guide on iOS, retaining the existing Catalyst bottom constraint. Continue using `updateCurrentMessageListInsets()` to derive the list's bottom content and scroll-indicator insets from the editor's presentation position, so the keyboard still obscures no messages while the message-list viewport and row geometry remain stable.

## Testing

- On iOS, load the main controller and verify its chat content host is constrained to the container bottom while the editor is anchored to `ChatView.keyboardLayoutGuide.top`; the message-list container therefore retains full-height bounds when keyboard avoidance is active.
- In a long conversation on an iOS 26 simulator or device, position a cell immediately below the visible area, focus the editor, then dismiss the keyboard; the cell should enter normally without stretching or moving from the top.
- With the conversation already at the bottom, show and hide the keyboard and verify the latest message remains above the editor throughout the transition and the scroll indicator ends above the editor.
- Scroll away from the bottom before showing and hiding the keyboard; the user's reading position should remain stable instead of being forced to the newest message.
- Build or exercise the Catalyst layout path and verify the editor remains anchored to the chat view bottom with no keyboard-guide behavior change.

Fixes #255
