### PR TITLE
Fall Back To Plain Text For Conversation Titles

### DIFF
--- a/FlowDown/Backend/Conversation/ConversationManager+Menu.swift
+++ b/FlowDown/Backend/Conversation/ConversationManager+Menu.swift
@@ -162,10 +162,9 @@ extension ConversationManager {
             ],
         )
 
-        let metadataModel = session.models.auxiliary ?? session.models.chat
-        let metadataModelSupportsTools = metadataModel
-            .map { ModelManager.shared.modelCapabilities(identifier: $0).contains(.tool) }
-            ?? false
+        // Title generation falls back to a plain completion when the model
+        // cannot answer a forced tool call, so the action is never gated on
+        // tool capability — a greyed-out entry reads as a broken feature.
         let automationMenu = UIMenu(
             title: String(localized: "Automation"),
             options: [.displayInline],
@@ -173,7 +172,6 @@ extension ConversationManager {
                 UIAction(
                     title: String(localized: "Generate New Title"),
                     image: UIImage(systemName: "arrow.clockwise"),
-                    attributes: metadataModelSupportsTools ? [] : [.disabled],
                 ) { _ in
                     Indicator.progress(
                         title: "Generating New Title",

--- a/FlowDown/Backend/Conversation/Pipeline/PostAction/ConversationSession+Metadata.swift
+++ b/FlowDown/Backend/Conversation/Pipeline/PostAction/ConversationSession+Metadata.swift
@@ -126,11 +126,32 @@ extension ConversationSessionManager.Session {
         }
 
         guard let model = models.auxiliary else { return nil }
-        guard ModelManager.shared.modelCapabilities(identifier: model).contains(.tool) else {
-            Logger.model.infoFile("skipping conversation metadata generation: model has no tool call capability")
-            return nil
+
+        if ModelManager.shared.modelCapabilities(identifier: model).contains(.tool),
+           let metadata = await generateMetadataWithToolCall(
+               model: model,
+               userMessage: userMessage,
+               assistantMessage: assistantMessage,
+           ) {
+            return metadata
         }
 
+        // Not every auxiliary endpoint answers a forced tool call — plain chat
+        // models and proxy endpoints without tool support among them. A plain
+        // completion still produces a title, so fall back instead of skipping.
+        Logger.model.infoFile("conversation metadata generation: using plain-text fallback")
+        return await generateMetadataWithPlainText(
+            model: model,
+            userMessage: userMessage,
+            assistantMessage: assistantMessage,
+        )
+    }
+
+    private func generateMetadataWithToolCall(
+        model: ModelManager.ModelIdentifier,
+        userMessage: String,
+        assistantMessage: String,
+    ) async -> ConversationMetadata? {
         let input: [ChatRequestBody.Message] = [
             .system(content: .text(
                 "Generate metadata for the conversation. You must call \(ConversationMetadataToolCall.name) exactly once with a title and an icon. Do not respond with plain text.",
@@ -164,6 +185,113 @@ extension ConversationSessionManager.Session {
             Logger.model.errorFile("failed to generate conversation metadata: \(error)")
             return nil
         }
+    }
+
+    private func generateMetadataWithPlainText(
+        model: ModelManager.ModelIdentifier,
+        userMessage: String,
+        assistantMessage: String,
+    ) async -> ConversationMetadata? {
+        let input: [ChatRequestBody.Message] = [
+            .system(content: .text(
+                """
+                Generate metadata for the conversation. Respond with ONLY one JSON object in this exact shape, with no markdown, code fence, or commentary:
+                {"title": "3-5 word title in the user's primary language, no prefix, label, or markdown", "icon": "a single emoji"}
+                """,
+            )),
+            .user(content: .text(
+                """
+                [last user message]
+                \(userMessage)
+
+                [last assistant message]
+                \(assistantMessage)
+                """,
+            )),
+        ]
+
+        do {
+            let response = try await ModelManager.shared.infer(with: model, input: input)
+            return ConversationMetadataPlainTextParser.parse(response.text)
+        } catch {
+            Logger.model.errorFile("failed to generate conversation metadata (plain text): \(error)")
+            return nil
+        }
+    }
+}
+
+/// Reads a title and an icon out of a plain completion. Models without tool
+/// support format their answer however they please, so this tries a JSON
+/// object first, then `title:` / `icon:` lines, and finally takes the first
+/// line as the title.
+enum ConversationMetadataPlainTextParser {
+    private struct PlainArguments: Decodable {
+        let title: String?
+        let icon: String?
+    }
+
+    static func parse(_ response: String) -> ConversationMetadata? {
+        if let metadata = parseJSONObject(in: response) { return metadata }
+        if let metadata = parseLabeledLines(in: response) { return metadata }
+        return parseFirstLine(in: response)
+    }
+
+    private static func parseJSONObject(in response: String) -> ConversationMetadata? {
+        guard let start = response.firstIndex(of: "{"),
+              let end = response.lastIndex(of: "}"),
+              start < end,
+              let data = response[start ... end].data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(PlainArguments.self, from: data)
+        else {
+            return nil
+        }
+
+        let metadata = ConversationMetadata(
+            title: ConversationMetadataToolCall.normalizedTitle(decoded.title),
+            icon: ConversationMetadataToolCall.normalizedIcon(decoded.icon),
+        )
+        return metadata.hasGeneratedContent ? metadata : nil
+    }
+
+    private static func parseLabeledLines(in response: String) -> ConversationMetadata? {
+        var title: String?
+        var icon: String?
+
+        for rawLine in response.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard let colon = line.firstIndex(where: { $0 == ":" || $0 == "：" }) else { continue }
+
+            let quoteAndSpace = CharacterSet.whitespacesAndNewlines.union(.init(charactersIn: "\"'`"))
+            let key = line[..<colon].trimmingCharacters(in: quoteAndSpace)
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: quoteAndSpace)
+
+            switch key.lowercased() {
+            case "title", "标题": title = value
+            case "icon", "emoji", "图标": icon = value
+            default: break
+            }
+        }
+
+        guard title != nil || icon != nil else { return nil }
+
+        let metadata = ConversationMetadata(
+            title: ConversationMetadataToolCall.normalizedTitle(title),
+            icon: ConversationMetadataToolCall.normalizedIcon(icon),
+        )
+        return metadata.hasGeneratedContent ? metadata : nil
+    }
+
+    private static func parseFirstLine(in response: String) -> ConversationMetadata? {
+        let line = response.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty }
+        guard let line else { return nil }
+
+        let metadata = ConversationMetadata(
+            title: ConversationMetadataToolCall.normalizedTitle(line),
+            icon: nil,
+        )
+        return metadata.hasGeneratedContent ? metadata : nil
     }
 }
 


### PR DESCRIPTION
## Summary

Since forced tool calls replaced the XML flow, title/icon generation is skipped entirely when the auxiliary model lacks tool capability — plain chat models and many proxy endpoints qualify, so new conversations stay untitled and **Automation → Generate New Title** is greyed out for those users.

This keeps the forced tool call when the model answers it, and otherwise falls back to a plain completion:

- system prompt asks for a single JSON object `{"title": ..., "icon": ...}`;
- parsing tries the JSON object first, then `title:` / `icon:` labeled lines, then the first non-empty line as the title — the same normalization rules (trim, strip bold markers, 32-char cap, single-emoji icon) apply;
- failures still surface as before (log + “Unable to generate title” indicator).

The menu entry is no longer gated on tool capability, since generation now works without it.

## Why

The auxiliary model defaults to the current chat model. Users chatting through tool-less endpoints (common with custom/proxy providers) currently get no automatic titles at all — a visible regression from the XML era.

## Testing

- [x] Tool-capable auxiliary model: generation goes through the existing tool-call path unchanged
- [x] Tool-less model: title and icon generated via the plain-text fallback
- [x] Menu entry enabled in both cases; manual “Generate New Title” works
- [x] Garbage model output degrades gracefully (first-line title or error indicator)