### PR TITLE
Size Sheets To The Window They Open Over

### DIFF
--- a/FlowDown/Extension/ModalWindowSize.swift
+++ b/FlowDown/Extension/ModalWindowSize.swift
@@ -1,0 +1,38 @@
+//
+//  ModalWindowSize.swift
+//  FlowDown
+//
+
+import UIKit
+
+/// Size for sheet-style windows (settings, code viewer) on top of the main
+/// window.
+///
+/// Sheets follow the main window at 80% of its size, clamped by a minimum
+/// that keeps their content usable and a maximum that keeps them from
+/// spanning wall-sized displays edge to edge. A window too small for the
+/// minimum gets the largest sheet that still fits it.
+enum ModalWindowSize {
+    static let minimum = CGSize(width: 720, height: 640)
+    static let maximum = CGSize(width: 1200, height: 800)
+    static let fractionOfWindow: CGFloat = 0.8
+
+    static func resolve(in window: UIWindow?) -> CGSize {
+        guard let bounds = window?.bounds.size else { return minimum }
+        let width = min(max(bounds.width * fractionOfWindow, minimum.width), maximum.width)
+        let height = min(max(bounds.height * fractionOfWindow, minimum.height), maximum.height)
+        // The holder pins its content to these constants; keep them inside
+        // what the window can actually host so the two never fight.
+        return CGSize(
+            width: min(width, max(bounds.width - 32, 0)),
+            height: min(height, max(bounds.height - 32, 0))
+        )
+    }
+
+    static var keyWindow: UIWindow? {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+        return windows.first(where: \.isKeyWindow) ?? windows.first
+    }
+}

--- a/FlowDown/Extension/ModalWindowSize.swift
+++ b/FlowDown/Extension/ModalWindowSize.swift
@@ -28,11 +28,4 @@ enum ModalWindowSize {
             height: min(height, max(bounds.height - 32, 0))
         )
     }
-
-    static var keyWindow: UIWindow? {
-        let windows = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap(\.windows)
-        return windows.first(where: \.isKeyWindow) ?? windows.first
-    }
 }

--- a/FlowDown/Interface/MessageListView/MessageListView+Adapter.swift
+++ b/FlowDown/Interface/MessageListView/MessageListView+Adapter.swift
@@ -490,19 +490,20 @@ extension MessageListView {
             controller.title = title
         }
 
+        let size = ModalWindowSize.resolve(in: parentViewController?.view.window ?? ModalWindowSize.keyWindow)
         #if targetEnvironment(macCatalyst)
             let nav = UINavigationController(rootViewController: controller)
             nav.view.backgroundColor = .background
             let holder = AlertBaseController(
                 rootViewController: nav,
-                preferredWidth: 555,
-                preferredHeight: 555,
+                preferredWidth: size.width,
+                preferredHeight: size.height,
             )
             holder.shouldDismissWhenTappedAround = true
             holder.shouldDismissWhenEscapeKeyPressed = true
         #else
             let holder = UINavigationController(rootViewController: controller)
-            holder.preferredContentSize = .init(width: 555, height: 555 - holder.navigationBar.frame.height)
+            holder.preferredContentSize = .init(width: size.width, height: size.height - holder.navigationBar.frame.height)
             holder.modalTransitionStyle = .coverVertical
             holder.modalPresentationStyle = .formSheet
             holder.view.backgroundColor = .background

--- a/FlowDown/Interface/MessageListView/MessageListView+Adapter.swift
+++ b/FlowDown/Interface/MessageListView/MessageListView+Adapter.swift
@@ -490,7 +490,7 @@ extension MessageListView {
             controller.title = title
         }
 
-        let size = ModalWindowSize.resolve(in: parentViewController?.view.window ?? ModalWindowSize.keyWindow)
+        let size = ModalWindowSize.resolve(in: parentViewController?.view.window)
         #if targetEnvironment(macCatalyst)
             let nav = UINavigationController(rootViewController: controller)
             nav.view.backgroundColor = .background
@@ -503,7 +503,7 @@ extension MessageListView {
             holder.shouldDismissWhenEscapeKeyPressed = true
         #else
             let holder = UINavigationController(rootViewController: controller)
-            holder.preferredContentSize = .init(width: size.width, height: size.height - holder.navigationBar.frame.height)
+            holder.preferredContentSize = .init(width: 555, height: 555 - holder.navigationBar.frame.height)
             holder.modalTransitionStyle = .coverVertical
             holder.modalPresentationStyle = .formSheet
             holder.view.backgroundColor = .background

--- a/FlowDown/Interface/SettingController/SettingController.swift
+++ b/FlowDown/Interface/SettingController/SettingController.swift
@@ -26,10 +26,11 @@ import UIKit
 
         override convenience init() {
             let nav = NavigationController()
+            let size = ModalWindowSize.resolve(in: ModalWindowSize.keyWindow)
             self.init(
                 rootViewController: nav,
-                preferredWidth: 600,
-                preferredHeight: 600,
+                preferredWidth: size.width,
+                preferredHeight: size.height,
             )
 
             content = nav
@@ -87,7 +88,8 @@ import UIKit
             navigationBar.prefersLargeTitles = false
             modalPresentationStyle = .formSheet
             modalTransitionStyle = .coverVertical
-            preferredContentSize = .init(width: 550, height: 550 - navigationBar.height)
+            let size = ModalWindowSize.resolve(in: ModalWindowSize.keyWindow)
+            preferredContentSize = .init(width: size.width, height: size.height - navigationBar.height)
             view.backgroundColor = .background
         }
 

--- a/FlowDown/Interface/SettingController/SettingController.swift
+++ b/FlowDown/Interface/SettingController/SettingController.swift
@@ -24,18 +24,40 @@ import UIKit
 
         var content: NavigationController! = .init()
 
+        private var sheetSizingConstraints: [NSLayoutConstraint] = []
+
         override convenience init() {
             let nav = NavigationController()
-            let size = ModalWindowSize.resolve(in: ModalWindowSize.keyWindow)
+            // No fixed size up front: the sheet sizes itself against the
+            // window it is actually presented into, read once it is there.
             self.init(
                 rootViewController: nav,
-                preferredWidth: size.width,
-                preferredHeight: size.height,
+                preferredWidth: nil,
+                preferredHeight: nil,
             )
 
             content = nav
             shouldDismissWhenTappedAround = false
             shouldDismissWhenEscapeKeyPressed = true
+        }
+
+        override func viewWillLayoutSubviews() {
+            super.viewWillLayoutSubviews()
+            // Size against the window the sheet is actually presented into,
+            // refreshing on every pass so a live window resize is followed.
+            guard let window = view.window else { return }
+            let size = ModalWindowSize.resolve(in: window)
+            if sheetSizingConstraints.isEmpty {
+                let constraints = [
+                    contentView.widthAnchor.constraint(equalToConstant: size.width),
+                    contentView.heightAnchor.constraint(equalToConstant: size.height),
+                ]
+                NSLayoutConstraint.activate(constraints)
+                sheetSizingConstraints = constraints
+            } else {
+                sheetSizingConstraints[0].constant = size.width
+                sheetSizingConstraints[1].constant = size.height
+            }
         }
 
         override func contentViewDidLoad() {
@@ -88,8 +110,7 @@ import UIKit
             navigationBar.prefersLargeTitles = false
             modalPresentationStyle = .formSheet
             modalTransitionStyle = .coverVertical
-            let size = ModalWindowSize.resolve(in: ModalWindowSize.keyWindow)
-            preferredContentSize = .init(width: size.width, height: size.height - navigationBar.height)
+            preferredContentSize = .init(width: 550, height: 550 - navigationBar.height)
             view.backgroundColor = .background
         }
 


### PR DESCRIPTION
## Summary

The code viewer and the settings sheet open at fixed sizes (555×555 / 600×600) regardless of the window — cramped on a wide Mac display, where the app is typically used windowed or full-screen.

Adds `ModalWindowSize`: sheets follow their window at **80% of its size**, clamped to a **720×640 minimum** (content stays usable) and a **1200×800 maximum** (no wall-spanning sheets on huge displays). A window too small for the minimum gets the largest sheet that still fits.

The size is always read from the view hierarchy — never a key-window lookup:

- **Settings sheet** (Catalyst): presented without a fixed size; it installs its own size constraints in `viewWillLayoutSubviews` against the window it is actually presented into, refreshing on every pass so a live window resize is followed. No call sites change.
- **Code viewer** (Catalyst): resolved from the presenting controller's `view.window`.
- iOS form-sheet branches keep their existing fixed preferred sizes.

## Testing

- [x] Catalyst: settings sheet and code viewer follow window resizes (including while presented), clamped at the minimum/maximum
- [x] A window at the minimum size gets a fitting sheet without constraint conflicts
- [x] No key-window access anywhere in the change