### PR TITLE
Keep The Settings Close Button Visible

### DIFF
--- a/FlowDown/Interface/SettingController/SettingContent.swift
+++ b/FlowDown/Interface/SettingController/SettingContent.swift
@@ -92,13 +92,15 @@ extension SettingController {
             if #available(iOS 26, macCatalyst 26, *) {
                 navigationItem.rightBarButtonItem = .init(customView: closeButton)
             } else {
-                let closeView = UIView()
-                closeView.addSubview(closeButton)
+                // Float the button above the scrolling content instead of
+                // scrolling away with the first row — the reader has to be
+                // able to close the sheet from wherever they are in it.
+                view.addSubview(closeButton)
                 closeButton.snp.makeConstraints { make in
-                    make.top.right.bottom.equalToSuperview()
+                    make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(8)
+                    make.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-8)
                     make.width.height.equalTo(32)
                 }
-                stackView.addArrangedSubviewWithMargin(closeView)
             }
             closeButton.actionBlock = { [weak self] in
                 self?.navigationController?.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
## Summary

On systems without the iOS 26 navigation-bar placement, the settings close button is the first row of the scrolling stack — scroll down and it is gone, leaving the sheet with no visible way to close it (escape still works on Catalyst, but touch/iOS users are stranded until they scroll back up).

Float the same circle button above the scrolling content, pinned to the top-right corner inside the safe area. It keeps its existing style (opaque background + border, 32pt, pudding animation), so it stays legible while content scrolls underneath.

The iOS 26 / macCatalyst 26 branch (navigation bar item) is untouched.

## Testing

- [x] Pre-26 branch: button stays visible at every scroll position and dismisses the sheet
- [x] Content below the corner remains readable (button sits in the top-right margin)
- [x] 26+ branch unchanged