### PR TITLE
Restore Star History Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Every model behaves differently based on its capabilities, deployment method, an
 
 For bulk management, FlowDown supports importing and exporting model configurations (`.fdmodel` files). You can script the generation of configuration files and import them all at once. Join our [Discord](https://discord.gg/UHKMRyJcgc) to discuss setups, but remember: community advice doesn't replace your own testing.
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lakr233/FlowDown&type=date&legend=top-left)](https://star-history.dera.page/#Lakr233/FlowDown&type=date&legend=top-left)
+
 ## License
 
 The source code is licensed under AGPL-3.0. You can find the full license text in the [LICENSE](./LICENSE) file.

--- a/Resources/i18n/zh-Hans/README.md
+++ b/Resources/i18n/zh-Hans/README.md
@@ -59,6 +59,10 @@ FlowDown 内置了免费模型供您快速上手。如需更多控制权，可�
 
 如需批量管理，浮望支持导入和导出模型配置文件（`.fdmodel` 格式）。你可以编写脚本批量生成配置文件，然后一次性导入。欢迎加入我们的 [Discord](https://discord.gg/UHKMRyJcgc) 讨论配置方案，但请记住：社区建议不能替代你自己的测试验证。
 
+## Star 历史
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lakr233/FlowDown&type=date&legend=top-left)](https://star-history.dera.page/#Lakr233/FlowDown&type=date&legend=top-left)
+
 ## 许可证
 
 项目源代码基于 AGPL-3.0 许可证。你可以在 [LICENSE](../../../LICENSE) 文件中找到完整的许可证文本。


### PR DESCRIPTION
The Star History chart was removed from the README in 5c9cd38 (Refine reminder callback and clean docs). The previous chart relied on a service whose endpoint is no longer functional under GitHub's stargazer API restrictions, so the section was dropped rather than fixed.

This change brings the chart back in both the main README and the zh-Hans README, at the same location it occupied before its removal, now backed by a reliable star history service. Restoring it keeps the documentation informative and gives contributors a live view of the project's adoption.