### PR TITLE
Protect The Current User Message From Context Trims

### DIFF
--- a/FlowDown/Backend/Conversation/Pipeline/Execute/ConversationSession+Execute.swift
+++ b/FlowDown/Backend/Conversation/Pipeline/Execute/ConversationSession+Execute.swift
@@ -234,7 +234,12 @@ extension ConversationSession {
         // MARK: - 删除超出上下文长度限制的消息
 
         try checkCancellation()
-        if try removeOutOfContextContents(&requestMessages, toolsDefinitions, modelContextLength) {
+        if try removeOutOfContextContents(
+            &requestMessages,
+            toolsDefinitions,
+            modelContextLength,
+            preservesReasoning: modelCapabilities.contains(.preservedThinking),
+        ) {
             let hintMessage = appendNewMessage(role: .hint)
             hintMessage.update(\.document, to: String(localized: "Some messages have been removed to fit the model context length."))
             await requestUpdate()

--- a/FlowDown/Backend/Conversation/Pipeline/Execute/ConversationSession+Trim.swift
+++ b/FlowDown/Backend/Conversation/Pipeline/Execute/ConversationSession+Trim.swift
@@ -13,10 +13,12 @@ extension ConversationSession {
         _ requestMessages: inout [ChatRequestBody.Message],
         _ tools: [ChatRequestBody.Tool]?,
         _ modelContextLength: Int,
+        preservesReasoning: Bool,
     ) throws -> Bool {
         let estimatedTokenCount = ModelManager.shared.calculateEstimateTokensUsingCommonEncoder(
             input: requestMessages,
             tools: tools ?? [],
+            includingReasoning: preservesReasoning,
         )
         Logger.model.debugFile("estimated token count: \(estimatedTokenCount)")
 
@@ -25,10 +27,15 @@ extension ConversationSession {
         }
 
         // Phase 1: Identify — collect indices of messages to evict (front-to-back, skip system)
+        //
+        // The final message carries the user's current input. Evicting it
+        // would send the provider a request with no user content at all,
+        // and the model would answer as if the user had said nothing.
+        let evictionUpperBound = requestMessages.isEmpty ? 0 : requestMessages.count - 1
         var indicesToEvict: [Int] = []
         var currentTokenCount = estimatedTokenCount
 
-        for idx in 0 ..< requestMessages.count {
+        for idx in 0 ..< evictionUpperBound {
             guard currentTokenCount > modelContextLength else { break }
             let item = requestMessages[idx]
             if case .system = item { continue }
@@ -41,6 +48,7 @@ extension ConversationSession {
             currentTokenCount = ModelManager.shared.calculateEstimateTokensUsingCommonEncoder(
                 input: candidateMessages,
                 tools: tools ?? [],
+                includingReasoning: preservesReasoning,
             )
         }
 

--- a/FlowDown/Backend/Model/ModelManager+Inference.swift
+++ b/FlowDown/Backend/Model/ModelManager+Inference.swift
@@ -426,6 +426,7 @@ extension ModelManager {
     func calculateEstimateTokensUsingCommonEncoder(
         input: [ChatRequestBody.Message],
         tools: [ChatRequestBody.Tool],
+        includingReasoning: Bool = true,
     ) -> Int {
         assert(!Thread.isMainThread)
 
@@ -451,7 +452,10 @@ extension ModelManager {
             case let .assistant(content, toolCalls, reasoning):
                 estimatedInferenceText += "role: assistant\n"
                 if let content { estimatedInferenceText += text(content) }
-                if let reasoning, !reasoning.isEmpty {
+                // Reasoning only reaches the wire for preserved-thinking
+                // models; counting it otherwise inflates the estimate and
+                // triggers evictions the provider would never ask for.
+                if includingReasoning, let reasoning, !reasoning.isEmpty {
                     estimatedInferenceText += "reasoning: \(reasoning)\n"
                 }
                 if let toolCalls, !toolCalls.isEmpty {

--- a/FlowDownUnitTests/ConversationTrimTests.swift
+++ b/FlowDownUnitTests/ConversationTrimTests.swift
@@ -1,0 +1,143 @@
+//
+//  ConversationTrimTests.swift
+//  FlowDownUnitTests
+//
+//  Created by GPT-5 Codex on 8/16/26.
+//
+
+@preconcurrency @testable import FlowDown
+import ChatClientKit
+import Foundation
+import Storage
+import Testing
+
+@Suite(.serialized)
+struct ConversationTrimTests {
+    @Test
+    @MainActor
+    func `trim keeps the current user message when older turns overflow the context`() async throws {
+        try await withTemporarySession { _, session in
+            let filler = String(repeating: "previous conversation content. ", count: 400)
+            var requestMessages: [ChatRequestBody.Message] = [
+                .system(content: .text("You are a helpful assistant.")),
+                .user(content: .text(filler)),
+                .assistant(content: .text(filler)),
+                .user(content: .text("What is the capital of France?")),
+            ]
+
+            let trimmed = try await runOffMain {
+                try session.removeOutOfContextContents(
+                    &requestMessages,
+                    nil,
+                    512,
+                    preservesReasoning: false,
+                )
+            }
+
+            #expect(trimmed)
+            #expect(requestMessages.count == 2)
+            guard case .system = requestMessages[0] else {
+                Issue.record("expected the system message to survive the trim")
+                return
+            }
+            guard case let .user(content, _) = requestMessages[1],
+                  case let .text(text) = content
+            else {
+                Issue.record("expected the final user message to survive the trim")
+                return
+            }
+            #expect(text == "What is the capital of France?")
+        }
+    }
+
+    @Test
+    @MainActor
+    func `trim throws rather than dropping the user message when nothing else can be evicted`() async throws {
+        try await withTemporarySession { _, session in
+            let filler = String(repeating: "system prompt segment. ", count: 400)
+            var requestMessages: [ChatRequestBody.Message] = [
+                .system(content: .text(filler)),
+                .user(content: .text("Hello")),
+            ]
+
+            let threw = await runOffMain {
+                do {
+                    _ = try session.removeOutOfContextContents(
+                        &requestMessages,
+                        nil,
+                        64,
+                        preservesReasoning: false,
+                    )
+                    return false
+                } catch {
+                    return true
+                }
+            }
+
+            #expect(threw)
+            #expect(requestMessages.count == 2)
+            guard case .user = requestMessages[1] else {
+                Issue.record("the failed trim must leave the user message in place")
+                return
+            }
+        }
+    }
+
+    @Test
+    func `reasoning is excluded from the token estimate unless the model preserves thinking`() async throws {
+        let reasoning = String(repeating: "let me think about this step by step. ", count: 200)
+        let messages: [ChatRequestBody.Message] = [
+            .assistant(content: .text("short answer"), reasoning: reasoning),
+        ]
+
+        let withReasoning = try await runOffMain {
+            ModelManager.shared.calculateEstimateTokensUsingCommonEncoder(
+                input: messages,
+                tools: [],
+                includingReasoning: true,
+            )
+        }
+        let withoutReasoning = try await runOffMain {
+            ModelManager.shared.calculateEstimateTokensUsingCommonEncoder(
+                input: messages,
+                tools: [],
+                includingReasoning: false,
+            )
+        }
+
+        #expect(withReasoning > withoutReasoning + 100)
+    }
+}
+
+private extension ConversationTrimTests {
+    @MainActor
+    func withTemporarySession(
+        _ body: @MainActor (Conversation, ConversationSession) async throws -> Void,
+    ) async throws {
+        try await FlowDownTestContext.shared.ensureBootstrappedEnvironment()
+
+        let conversation = sdb.conversationMake { conversation in
+            conversation.update(\.title, to: "Trim Tests \(UUID().uuidString.prefix(8))")
+        }
+        let session = ConversationSessionManager.shared.session(for: conversation.id)
+
+        do {
+            try await body(conversation, session)
+            ConversationManager.shared.deleteConversation(identifier: conversation.id)
+        } catch {
+            ConversationManager.shared.deleteConversation(identifier: conversation.id)
+            throw error
+        }
+    }
+
+    /// The token estimator asserts it runs off the main thread.
+    func runOffMain<T: Sendable>(
+        _ work: @escaping @Sendable () throws -> T,
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(with: .init(catching: work))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #295.

When the assembled request exceeds `modelContextLength`, the eviction loop in `removeOutOfContextContents` scans every index — including the final message, which carries the user's current input. Once system-side injections (dynamic info, memory, conversation summaries) grow past the budget, the request that reaches the provider can contain only system messages, and the model answers as if the user had said nothing.

Two changes:

- **Trim**: the eviction scan now stops at `requestMessages.count - 1`, so the current user message always survives. If nothing else can be evicted, the function throws the existing "unable to remove any more messages" error instead of silently dropping the user's input.
- **Estimate**: `calculateEstimateTokensUsingCommonEncoder` takes an `includingReasoning` flag, driven by the model's `preservedThinking` capability. Reasoning only reaches the wire for preserved-thinking models; counting it otherwise inflates the estimate and triggers evictions the provider would never ask for.

## Testing

- [x] Added `FlowDownUnitTests/ConversationTrimTests.swift`:
  - trim keeps the current user message when older turns overflow the context
  - trim throws rather than dropping the user message when nothing else can be evicted
  - reasoning is excluded from the token estimate unless the model preserves thinking
- [x] Verified on a fork build (macOS, both architectures) that a conversation which previously got a generic "how can I help" reply now receives and answers the actual user message

## Notes

No localization, generated asset, or DevKit script changes.